### PR TITLE
Pve changes

### DIFF
--- a/src/main/java/com/ebicep/warlords/abilities/Berserk.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Berserk.java
@@ -111,7 +111,7 @@ public class Berserk extends AbstractAbility implements OrangeAbilityIcon, Durat
                     if (event.getCause().isEmpty() || event.getCause().equals("Time Warp")) {
                         return currentCritChance;
                     }
-                    float critBoost = (0.5f * multiplier);
+                    float critBoost = (1f * multiplier);
                     return currentCritChance + Math.min(60, critBoost);
                 }
                 return currentCritChance;
@@ -123,7 +123,7 @@ public class Berserk extends AbstractAbility implements OrangeAbilityIcon, Durat
                     if (event.getCause().isEmpty() || event.getCause().equals("Time Warp")) {
                         return currentCritMultiplier;
                     }
-                    float critBoost = (0.5f * multiplier);
+                    float critBoost = (1f * multiplier);
                     return currentCritMultiplier + Math.min(60, critBoost);
                 }
                 return currentCritMultiplier;
@@ -157,8 +157,8 @@ public class Berserk extends AbstractAbility implements OrangeAbilityIcon, Durat
                     return;
                 }
 
-                float finalValue = Math.min(20000, absorbedDamage);
-                wp.addEnergy(wp, "Berserk Master Upgrade", finalValue * 0.005f);
+                float finalValue = Math.min(50000, absorbedDamage);
+                wp.addEnergy(wp, "Berserk Master Upgrade", finalValue * 0.002f);
 
                 FallingBlockWaveEffect.create(wp.getLocation().clone().add(0, 1, 0), 10, 10, Material.AMETHYST_CLUSTER);
                         Utils.playGlobalSound(wp.getLocation(), "warrior.mortalstrike.impact", 2, 0.5f);
@@ -172,7 +172,7 @@ public class Berserk extends AbstractAbility implements OrangeAbilityIcon, Durat
                             .damage()
                             .cause("Berserk Unleashed")
                             .source(wp)
-                            .value(finalValue * 0.4f)
+                            .value(finalValue * 0.15f)
                             .flags(InstanceFlags.IGNORE_DAMAGE_BOOST, InstanceFlags.NO_LUST_HEALING)
                     );
                 }

--- a/src/main/java/com/ebicep/warlords/abilities/ConsecrateProtector.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ConsecrateProtector.java
@@ -63,10 +63,16 @@ public class ConsecrateProtector extends AbstractConsecrate implements CanReduce
                 circleEffect.playEffects();
             }
             if (ticksElapsed % 30 == 0) {
+                timesReduced.set(0);
                 PlayerFilter.entitiesAround(updatedLocation, radius, 6, radius).aliveEnemiesOf(wp).forEach(enemy -> {
                     getAbilityStats().addPlayersHit();
-                    enemy.addInstance(InstanceBuilder.damage().ability(this).source(wp).value(damageValues.consecrateDamage)).ifPresent(finalEvent -> {
-                        if (timesReduced.get() < 15) {
+                    enemy.addInstance(InstanceBuilder
+                            .damage()
+                            .ability(this)
+                            .source(wp)
+                            .value(damageValues.consecrateDamage)
+                            ).ifPresent(finalEvent -> {
+                        if (timesReduced.get() < 8) {
                             timesReduced.getAndIncrement();
                             wp.getAbilitiesMatching(HammerOfLight.class).forEach(holy -> holy.subtractCurrentCooldown(.25f));
                         }

--- a/src/main/java/com/ebicep/warlords/abilities/ConsecrateProtector.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ConsecrateProtector.java
@@ -72,7 +72,7 @@ public class ConsecrateProtector extends AbstractConsecrate implements CanReduce
                             .source(wp)
                             .value(damageValues.consecrateDamage)
                             ).ifPresent(finalEvent -> {
-                        if (timesReduced.get() < 8) {
+                        if (timesReduced.get() < 5) {
                             timesReduced.getAndIncrement();
                             wp.getAbilitiesMatching(HammerOfLight.class).forEach(holy -> holy.subtractCurrentCooldown(.25f));
                         }

--- a/src/main/java/com/ebicep/warlords/abilities/ContagiousFacade.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ContagiousFacade.java
@@ -80,6 +80,7 @@ public class ContagiousFacade extends AbstractAbility implements BlueAbilityIcon
                     Utils.playGlobalSound(wp.getLocation(), "mage.arcaneshield.activation", 2, 0.4f);
                     Utils.playGlobalSound(wp.getLocation(), Sound.ENTITY_EVOKER_PREPARE_ATTACK, 2, 2);
                     float shieldHealth = (float) totalAbsorbed.get();
+                    shieldHealth *= pveMasterUpgrade2 ? 2.5 : 1;
                     stats.totalShieldGained += shieldHealth;
                     Shield shield = new Shield(name, shieldHealth);
                     wp.getCooldownManager().addCooldown(new RegularCooldown<>(name + " Shield", "SHIELD", Shield.class, shield, wp, CooldownTypes.ABILITY, cooldownManager1 -> {
@@ -120,9 +121,6 @@ public class ContagiousFacade extends AbstractAbility implements BlueAbilityIcon
             public float modifyDamageAfterInterveneFromSelf(WarlordsDamageHealingEvent event, float currentDamageValue) {
                 float afterValue = currentDamageValue * convertToDivisionDecimal(damageAbsorption.getCalculatedValue());
                 float absorbedAmount = currentDamageValue - afterValue;
-                if (pveMasterUpgrade2 && totalAbsorbed.get() + absorbedAmount >= wp.getMaxHealth()) {
-                    return currentDamageValue;
-                }
                 totalAbsorbed.addAndGet(absorbedAmount);
                 return afterValue;
             }
@@ -190,7 +188,7 @@ public class ContagiousFacade extends AbstractAbility implements BlueAbilityIcon
                                                     .closestFirst(wp)
                                                     .limit(pveMasterUpgrade ? Integer.MAX_VALUE : infectedPlayers)) {
             EffectUtils.playParticleLinkAnimation(wp.getLocation(), hexTarget.getLocation(), 180, 0, 0, 2);
-            for (int i = 0; i < stacksGranted; i++) {
+            for (int i = 0; i < (inPve ? 3 : stacksGranted); i++) {
                 PoisonousHex.givePoisonousHex(wp, hexTarget);
                 EffectUtils.displayParticle(Particle.CRIMSON_SPORE, wp.getLocation(), 20, 0.05, 0.1, 0.05, 0.25);
             }
@@ -203,8 +201,8 @@ public class ContagiousFacade extends AbstractAbility implements BlueAbilityIcon
             stats.totalHexesInflicted++;
         }
         if (pveMasterUpgrade) {
-            wp.getCooldownManager().addCooldown(new RegularCooldown<>(name, "FACADE", ContagiousFacade.class, null, wp, CooldownTypes.ABILITY, cooldownManager -> {
-            }, 20 * 5
+            wp.getCooldownManager().addCooldown(new RegularCooldown<>(name, "FAC", ContagiousFacade.class, null, wp, CooldownTypes.ABILITY, cooldownManager -> {
+            }, 20 * 8
             ) {
 
                 @Override

--- a/src/main/java/com/ebicep/warlords/abilities/ContagiousFacade.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ContagiousFacade.java
@@ -188,7 +188,7 @@ public class ContagiousFacade extends AbstractAbility implements BlueAbilityIcon
                                                     .closestFirst(wp)
                                                     .limit(pveMasterUpgrade ? Integer.MAX_VALUE : infectedPlayers)) {
             EffectUtils.playParticleLinkAnimation(wp.getLocation(), hexTarget.getLocation(), 180, 0, 0, 2);
-            for (int i = 0; i < (inPve ? 3 : stacksGranted); i++) {
+            for (int i = 0; i < stacksGranted; i++) {
                 PoisonousHex.givePoisonousHex(wp, hexTarget);
                 EffectUtils.displayParticle(Particle.CRIMSON_SPORE, wp.getLocation(), 20, 0.05, 0.1, 0.05, 0.25);
             }

--- a/src/main/java/com/ebicep/warlords/abilities/EarthlivingWeapon.java
+++ b/src/main/java/com/ebicep/warlords/abilities/EarthlivingWeapon.java
@@ -143,7 +143,8 @@ public class EarthlivingWeapon extends AbstractAbility implements PurpleAbilityI
                 stats.timesProcd++;
                 Utils.playGlobalSound(victim.getLocation(), "shaman.earthlivingweapon.impact", 2, 1);
                 float cc = pveMasterUpgrade2 && !previosulyProcd ? 100 : healingValues.earthlivingHealing.getCritChanceValue();
-                List<WarlordsEntity> healedPlayers = PlayerFilter.entitiesAround(attacker, 6, 6, 6)
+                double area = inPve ? 8 : 6;
+                List<WarlordsEntity> healedPlayers = PlayerFilter.entitiesAround(attacker, area, area, area)
                                                                  .aliveTeammatesOfExcludingSelf(attacker)
                                                                  .warlordPlayersFirst()
                                                                  .limit(maxAllies)

--- a/src/main/java/com/ebicep/warlords/abilities/EarthlivingWeapon.java
+++ b/src/main/java/com/ebicep/warlords/abilities/EarthlivingWeapon.java
@@ -7,13 +7,11 @@ import com.ebicep.warlords.effects.EffectUtils;
 import com.ebicep.warlords.effects.FallingBlockWaveEffect;
 import com.ebicep.warlords.events.player.ingame.WarlordsDamageHealingEvent;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
-import com.ebicep.warlords.player.ingame.WarlordsNPC;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.type.CustomInstanceFlags;
-import com.ebicep.warlords.pve.mobs.flags.NoTargetAbilities;
 import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.shaman.earthwarden.EarthlivingWeaponBranch;
@@ -40,6 +38,7 @@ public class EarthlivingWeapon extends AbstractAbility implements PurpleAbilityI
     private int weaponDamage = 240;
     private int maxHits = 1;
     private int guaranteedHits = 1;
+    private float radius = 6;
 
     public EarthlivingWeapon() {
         super(AbstractAbilityBuilder.create("earthlivingWeapon").pvp());
@@ -143,8 +142,7 @@ public class EarthlivingWeapon extends AbstractAbility implements PurpleAbilityI
                 stats.timesProcd++;
                 Utils.playGlobalSound(victim.getLocation(), "shaman.earthlivingweapon.impact", 2, 1);
                 float cc = pveMasterUpgrade2 && !previosulyProcd ? 100 : healingValues.earthlivingHealing.getCritChanceValue();
-                double area = inPve ? 8 : 6;
-                List<WarlordsEntity> healedPlayers = PlayerFilter.entitiesAround(attacker, area, area, area)
+                List<WarlordsEntity> healedPlayers = PlayerFilter.entitiesAround(attacker, radius, radius, radius)
                                                                  .aliveTeammatesOfExcludingSelf(attacker)
                                                                  .warlordPlayersFirst()
                                                                  .limit(maxAllies)
@@ -227,6 +225,14 @@ public class EarthlivingWeapon extends AbstractAbility implements PurpleAbilityI
 
     public void setGuaranteedHits(int guaranteedHits) {
         this.guaranteedHits = guaranteedHits;
+    }
+
+    public float getRadius() {
+        return radius;
+    }
+
+    public void setRadius(float radius) {
+        this.radius = radius;
     }
 
     public float getProcChance() {

--- a/src/main/java/com/ebicep/warlords/abilities/IncendiaryCurse.java
+++ b/src/main/java/com/ebicep/warlords/abilities/IncendiaryCurse.java
@@ -110,7 +110,7 @@ public class IncendiaryCurse extends AbstractAbility implements RedAbilityIcon, 
     public void onImpact(@Nonnull WarlordsEntity wp, Location newLoc) {
         Utils.playGlobalSound(newLoc, Sound.ITEM_FLINTANDSTEEL_USE, 2, 0.1f);
         EffectUtils.playFirework(newLoc, FireworkEffect.builder().withColor(Color.ORANGE).withColor(Color.RED).with(FireworkEffect.Type.BURST).build(), 1);
-        EffectUtils.displayParticle(Particle.SMOKE, newLoc, 100, 0.4, 0.05, 0.4, 0.2);
+        EffectUtils.displayParticle(Particle.SMOKE, newLoc, 50, 0.4, 0.05, 0.4, 0.2);
         float hitboxValue = hitbox.getCalculatedValue();
         List<WarlordsEntity> enemies = PlayerFilter.entitiesAround(newLoc, hitboxValue, hitboxValue, hitboxValue).aliveEnemiesOf(wp).toList();
         for (WarlordsEntity nearEntity : enemies) {

--- a/src/main/java/com/ebicep/warlords/abilities/LightningBolt.java
+++ b/src/main/java/com/ebicep/warlords/abilities/LightningBolt.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.abilities.internal.*;
 import com.ebicep.warlords.abilities.internal.icon.WeaponAbilityIcon;
 import com.ebicep.warlords.database.repositories.config.ConfigManager;
 import com.ebicep.warlords.effects.EffectUtils;
+import com.ebicep.warlords.events.player.ingame.WarlordsDamageHealingEvent;
 import com.ebicep.warlords.events.player.ingame.WarlordsDamageHealingFinalEvent;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
@@ -12,6 +13,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.shaman.thunderlord.LightningBoltBranch;
 import com.ebicep.warlords.util.bukkit.EntitiesUtils;
 import com.ebicep.warlords.util.bukkit.LocationBuilder;
+import com.ebicep.warlords.util.bukkit.LocationUtils;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
 import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
@@ -30,6 +32,7 @@ import org.joml.Vector3f;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class LightningBolt extends AbstractPiercingProjectile<LightningBolt, LightningBolt.LightningBoltStats> implements Splash, WeaponAbilityIcon,
@@ -136,9 +139,9 @@ public class LightningBolt extends AbstractPiercingProjectile<LightningBolt, Lig
         float damageMultiplier = 1;
         if (pveMasterUpgrade2) {
             if (playersHit == 1) {
-                damageMultiplier = 1.35f;
+                damageMultiplier = 1.6f;
             } else {
-                damageMultiplier = 1.15f;
+                damageMultiplier = playersHit * 0.15f + 1.6f;
             }
             EffectUtils.displayParticle(Particle.ENCHANTED_HIT, hit.getLocation().add(0, 1.2, 0), 5, .25, .25, .25, 0);
         }
@@ -171,6 +174,7 @@ public class LightningBolt extends AbstractPiercingProjectile<LightningBolt, Lig
             }
             Utils.playGlobalSound(impactLocation, "shaman.lightningbolt.impact", 2, 1);
             hit(hit, wp, projectile);
+
             //reducing chain cooldown
             if (!(wp.isInPve() && projectile.getHit().size() > 2)) {
                 for (ChainLightning chainLightning : wp.getAbilitiesMatching(ChainLightning.class)) {

--- a/src/main/java/com/ebicep/warlords/abilities/OrderOfEviscerate.java
+++ b/src/main/java/com/ebicep/warlords/abilities/OrderOfEviscerate.java
@@ -126,7 +126,7 @@ public class OrderOfEviscerate extends AbstractAbility implements OrangeAbilityI
                 float damageBonus = vulnerableDamageBonus;
                 if (pveMasterUpgrade && !LocationUtils.isLineOfSightAssassin(event.getWarlordsEntity(), event.getSource())) {
                     stats.numberOfBackstabs++;
-                    damageBonus += 70;
+                    damageBonus += 120;
                 }
                 return currentDamageValue * (1 + damageBonus / 100f);
             }

--- a/src/main/java/com/ebicep/warlords/abilities/RecklessCharge.java
+++ b/src/main/java/com/ebicep/warlords/abilities/RecklessCharge.java
@@ -197,7 +197,7 @@ public class RecklessCharge extends AbstractAbility implements RedAbilityIcon, H
 
                                        @Override
                                        public float modifyHealingFromSelf(WarlordsDamageHealingEvent event, float currentHealValue) {
-                                           return currentHealValue * 2;
+                                           return currentHealValue * 1.5f;
                                        }
                                    });
                         new CooldownFilter<>(otherPlayer, RegularCooldown.class).filter(cd -> cd.getCooldownType() != CooldownTypes.LOW_LEVEL_DEBUFF)

--- a/src/main/java/com/ebicep/warlords/abilities/ShadowStep.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ShadowStep.java
@@ -14,6 +14,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.rogue.assassin.ShadowStepBranch;
 import com.ebicep.warlords.util.bukkit.LocationBuilder;
+import com.ebicep.warlords.util.java.MathUtils;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
@@ -115,7 +116,7 @@ public class ShadowStep extends AbstractAbility implements
 
     private void doShadowDash(@Nonnull WarlordsEntity wp) {
         wp.getCooldownManager().addCooldown(new RegularCooldown<>("Shadow Dash Damage Res", null, ShadowStep.class, new ShadowStep(), wp, CooldownTypes.BUFF, cooldownManager -> {
-        }, 2
+        }, 5
         ) {
 
             @Override
@@ -125,8 +126,10 @@ public class ShadowStep extends AbstractAbility implements
         });
         Set<WarlordsEntity> hit = new HashSet<>();
         AtomicInteger guaranteedCrit = new AtomicInteger(this.guaranteedCrit);
-        LocationBuilder locationBuilder = new LocationBuilder(wp.getEyeLocation());
-        for (Block ignored : Utils.getTargetBlockInBetween(wp.getEyeLocation(), 12)) {
+        Location startLocation = wp.getEyeLocation();
+        LocationBuilder locationBuilder = new LocationBuilder(startLocation);
+        int maxDistance = (int) MathUtils.calculateMaxDistance(Math.abs(locationBuilder.getPitch()), 10, 2);
+        for (Block ignored : Utils.getTargetBlockInBetween(wp.getEyeLocation(), maxDistance)) {
             if (!Utils.getTargetBlock(locationBuilder, 1).getType().isAir() ||
                     !locationBuilder.getBlock().getType().isAir() ||
                     !locationBuilder.clone()
@@ -140,7 +143,7 @@ public class ShadowStep extends AbstractAbility implements
                 locationBuilder.addY(isSlab ? -0.5 : 0);
                 break;
             }
-            PlayerFilter.entitiesAround(locationBuilder.clone().addY(-1), 2, 2, 2).aliveEnemiesOf(wp).excluding(hit).forEach(warlordsEntity -> {
+            PlayerFilter.entitiesAround(locationBuilder.clone().addY(-1), 3.5, 3.5, 3.5).aliveEnemiesOf(wp).excluding(hit).forEach(warlordsEntity -> {
                 hit.add(warlordsEntity);
                 warlordsEntity.addInstance(InstanceBuilder
                         .damage()
@@ -155,20 +158,22 @@ public class ShadowStep extends AbstractAbility implements
         }
         Utils.playGlobalSound(wp.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 2, 1.5f);
         wp.teleportLocationOnly(locationBuilder);
-        wp.getCooldownManager().addCooldown(new RegularCooldown<>("Shadow Dash CC", null, ShadowStep.class, new ShadowStep(), wp, CooldownTypes.BUFF, cooldownManager -> {
-        }, 5 * 20
-        ) {
+        if (hit.size() != 0) {
+            wp.getCooldownManager().addCooldown(new RegularCooldown<>("Shadow Dash", "SHDW", ShadowStep.class, new ShadowStep(), wp, CooldownTypes.BUFF, cooldownManager -> {
+            }, 5 * 20
+            ) {
 
-            @Override
-            public float addCritMultiplierFromAttacker(WarlordsDamageHealingEvent event, float currentCritMultiplier) {
-                return currentCritMultiplier * convertToMultiplicationDecimal(Math.min(2f * hit.size(), 20));
-            }
+                @Override
+                public float addCritMultiplierFromAttacker(WarlordsDamageHealingEvent event, float currentCritMultiplier) {
+                    return currentCritMultiplier + (Math.min(2f * hit.size(), 20));
+                }
 
-            @Override
-            public float addCritChanceFromAttacker(WarlordsDamageHealingEvent event, float currentCritChance) {
-                return currentCritChance * convertToMultiplicationDecimal(Math.min(2f * hit.size(), 20));
-            }
-        });
+                @Override
+                public float addCritChanceFromAttacker(WarlordsDamageHealingEvent event, float currentCritChance) {
+                    return currentCritChance + (Math.min(2f * hit.size(), 20));
+                }
+            });
+        }
     }
 
     private void doShadowStep(@Nonnull WarlordsEntity wp, Location playerLoc) {
@@ -184,7 +189,9 @@ public class ShadowStep extends AbstractAbility implements
                     .critChance(guaranteedCrit.getAndDecrement() > 0 ? 100 : damageValues.shadowStepDamage.getCritChanceValue())
             );
             Utils.playGlobalSound(playerLoc, "warrior.revenant.orbsoflife", 2, 1.9f);
-            playersHit.add(assaultTarget);
+            if (!pveMasterUpgrade) {
+                playersHit.add(assaultTarget);
+            }
         }
         new GameRunnable(wp.getGame()) {
 
@@ -224,10 +231,6 @@ public class ShadowStep extends AbstractAbility implements
     private void pveMasterOnLand(WarlordsEntity we) {
         we.addSpeedModifier(we, name, 80, 5 * 20);
         we.addKnockbackModifier(we, name, -80, 5 * 20);
-        for (IncendiaryCurse incendiaryCurse : we.getAbilitiesMatching(IncendiaryCurse.class)) {
-            incendiaryCurse.onImpact(we, we.getLocation());
-            break;
-        }
     }
 
     @Override

--- a/src/main/java/com/ebicep/warlords/abilities/TimeWarpPyromancer.java
+++ b/src/main/java/com/ebicep/warlords/abilities/TimeWarpPyromancer.java
@@ -78,7 +78,7 @@ public class TimeWarpPyromancer extends AbstractTimeWarp {
                             );
                             if (finalEventOptional.isPresent()) {
                                 if (finalEventOptional.get().isDead()) {
-                                    cooldownReduction += .75f;
+                                    cooldownReduction += 2f;
                                 }
                             }
                         }

--- a/src/main/java/com/ebicep/warlords/abilities/internal/Leech.java
+++ b/src/main/java/com/ebicep/warlords/abilities/internal/Leech.java
@@ -76,14 +76,14 @@ public class Leech {
                             if (!finalEvent.isDamageInstance()) {
                                 return;
                             }
-                            if (inPve && data.totalHealingDone >= 1000) {
-                                setTicksLeft(0);
-                                return;
-                            }
+//                            if (inPve && data.totalHealingDone >= 1000) {
+//                                setTicksLeft(0);
+//                                return;
+//                            }
                             float value = finalEvent.getValueBeforeAllReduction();
                             float healValue = value * AbstractAbility.convertToPercent(leechAmount * data.getStacksCount());
                             if (inPve) {
-                                healValue = Math.min(500, healValue);
+                                healValue = Math.min(300 * data.getStacksCount(), healValue);
                             }
                             finalEvent.getSource().addInstance(InstanceBuilder
                                     .healing()

--- a/src/main/java/com/ebicep/warlords/pve/items/types/fixeditems/DisasterFragment.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/fixeditems/DisasterFragment.java
@@ -178,17 +178,17 @@ public class DisasterFragment extends AbstractFixedItem implements FixedItemAppl
                         ) {
                             @Override
                             public void onDamageFromSelf(WarlordsDamageHealingEvent event, float currentDamageValue, boolean isCrit) {
-                                if (totalHealingDone.get() >= 1000) {
-                                    setTicksLeft(0);
-                                    return;
-                                }
+//                                if (totalHealingDone.get() >= 1000) {
+//                                    setTicksLeft(0);
+//                                    return;
+//                                }
                                 float healingMultiplier;
                                 if (event.getSource() == attacker) {
                                     healingMultiplier = 15;
                                 } else {
                                     healingMultiplier = 25;
                                 }
-                                float healValue = Math.min(500, currentDamageValue * healingMultiplier);
+                                float healValue = Math.min(300, currentDamageValue * healingMultiplier);
                                 event.getSource().addInstance(InstanceBuilder
                                         .healing()
                                         .cause("Leech")

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/conjurer/ContagiousFacadeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/conjurer/ContagiousFacadeBranch.java
@@ -56,7 +56,7 @@ public class ContagiousFacadeBranch extends AbstractUpgradeBranch<ContagiousFaca
                 """
                         +20% Cooldown Reduction
                         
-                        When reactivating Contagious Facade, increase EPS by 10 for 5 seconds and Poisonous Hex infliction now affects all enemies within the radius.
+                        When reactivating Contagious Facade, increase EPS by 10 for 8 seconds and Poisonous Hex infliction now affects all enemies within the radius.
                         """,
                 50000,
                 () -> {
@@ -68,14 +68,14 @@ public class ContagiousFacadeBranch extends AbstractUpgradeBranch<ContagiousFaca
                 "Contagious Facade - Master Upgrade",
                 """
                         +20% Cooldown Reduction
-                        2.5x Absorb Damage
+                        +20% Absorb Damage
                         
-                        Total damage absorbed is capped at the user's max hp.
+                        2.5x Shield Health
                         """,
                 50000,
                 () -> {
                     ability.getCooldown().addMultiplicativeModifierMult("Polluting Guise", 0.8f);
-                    ability.getDamageAbsorption().addMultiplicativeModifierMult("Master Upgrade Branch", 2.5f);
+                    ability.getDamageAbsorption().addAdditiveModifier("Polluting Guise", 20f);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/conjurer/ContagiousFacadeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/conjurer/ContagiousFacadeBranch.java
@@ -8,6 +8,10 @@ import javax.annotation.Nonnull;
 
 public class ContagiousFacadeBranch extends AbstractUpgradeBranch<ContagiousFacade> {
 
+    @Override
+    public void runOnce() {
+        ability.setStacksGranted(3);
+    }
     public ContagiousFacadeBranch(AbilityTree abilityTree, ContagiousFacade ability) {
         super(abilityTree, ability);
 

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/mage/pyromancer/FireballBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/mage/pyromancer/FireballBranch.java
@@ -11,8 +11,7 @@ public class FireballBranch extends AbstractUpgradeBranch<Fireball> {
 
         UpgradeTreeBuilder
                 .create(abilityTree, this)
-                .addUpgradeDamage(ability.getDamageValues().getFireballDamage(), 12.5f, 1, 2, 3)
-                .addUpgradeDamage(ability.getDamageValues().getFireballDamage(), 50f, 4)
+                .addUpgradeDamage(ability.getDamageValues().getFireballDamage(), 15f, 1, 2, 3, 4)
                 .addUpgrade(new UpgradeTypes.UpgradeType() {
                     @Override
                     public String getDescription0(String value) {
@@ -30,7 +29,7 @@ public class FireballBranch extends AbstractUpgradeBranch<Fireball> {
         UpgradeTreeBuilder
                 .create(abilityTree, this)
                 .addUpgradeSplash(ability, 0.5f)
-                .addUpgradeEnergy(ability, 3.75f)
+                .addUpgradeEnergy(ability, 5f)
                 .addTo(treeB);
 
         masterUpgrade = new Upgrade(

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/mage/pyromancer/InfernoBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/mage/pyromancer/InfernoBranch.java
@@ -23,12 +23,12 @@ public class InfernoBranch extends AbstractUpgradeBranch<Inferno> {
                     public void run(float value) {
                         ability.setCritMultiplierIncrease((int) (critMultiplierIncrease + value));
                     }
-                }, 15f)
+                }, 20f)
                 .addTo(treeA);
 
         UpgradeTreeBuilder
                 .create(abilityTree, this)
-                .addUpgradeDuration(ability)
+                .addUpgradeDuration(ability, 40f)
                 .addTo(treeB);
 
         masterUpgrade = new Upgrade(

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/mage/pyromancer/TimeWarpBranchPyromancer.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/mage/pyromancer/TimeWarpBranchPyromancer.java
@@ -34,19 +34,20 @@ public class TimeWarpBranchPyromancer extends AbstractUpgradeBranch<TimeWarpPyro
                 50000,
                 () -> {
                     ability.setTickDuration(ability.getTickDuration() * 2);
-
                 }
         );
         masterUpgrade2 = new Upgrade(
                 "Accursed Leap",
                 "Time Warp - Master Upgrade",
                 """
+                        -2s warp duration
+                        
                         After warping back, enemies within 12 blocks will combust dealing 7.5% of their max hp as damage.
-                        The cooldown of Time Warp is reduced by 0.75s for each enemy killed.
+                        The cooldown of Time Warp is reduced by 2s for each enemy killed.
                         """,
                 50000,
                 () -> {
-
+                    ability.setTickDuration(ability.getTickDuration() - 40);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/AbstractConsecrateBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/AbstractConsecrateBranch.java
@@ -9,6 +9,11 @@ import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
 
 public abstract class AbstractConsecrateBranch<T extends AbstractConsecrate> extends AbstractUpgradeBranch<T> {
 
+    @Override //lazy fix for m2 cons number of hits
+    public void runOnce() {
+        ability.setTickDuration(ability.getTickDuration() + 1);
+    }
+
     public AbstractConsecrateBranch(AbilityTree abilityTree, T ability) {
         super(abilityTree, ability);
 

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/AbstractConsecrateBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/AbstractConsecrateBranch.java
@@ -9,11 +9,6 @@ import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
 
 public abstract class AbstractConsecrateBranch<T extends AbstractConsecrate> extends AbstractUpgradeBranch<T> {
 
-    @Override //lazy fix for m2 cons number of hits
-    public void runOnce() {
-        ability.setTickDuration(ability.getTickDuration() + 1);
-    }
-
     public AbstractConsecrateBranch(AbilityTree abilityTree, T ability) {
         super(abilityTree, ability);
 

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/assassin/OrderOfEviscerateBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/assassin/OrderOfEviscerateBranch.java
@@ -33,7 +33,7 @@ public class OrderOfEviscerateBranch extends AbstractUpgradeBranch<OrderOfEvisce
                 """
                         +4s Duration
                         
-                        Kills while Order of Eviscerate is active reduce the cooldown by an additional 4 seconds. Additionally, attacks from behind deal 70% more damage.
+                        Kills while Order of Eviscerate is active reduce the cooldown by an additional 4 seconds. Additionally, attacks from behind deal 120% more damage.
                         """,
                 50000,
                 () -> {

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/assassin/ShadowStepBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/assassin/ShadowStepBranch.java
@@ -25,7 +25,7 @@ public class ShadowStepBranch extends AbstractUpgradeBranch<ShadowStep> {
         masterUpgrade = new Upgrade(
                 "Shadow Stagger",
                 "Shadow Step - Master Upgrade",
-                "Gain 80% speed and knockback resistance upon landing for 5 seconds. Additionally cast an Incendiary Curse upon landing at the block you landed on.",
+                "Gain 80% speed and knockback resistance upon landing for 5 seconds. Shadow Step can now hit the same enemy on leap and land.",
                 50000,
                 () -> {
 
@@ -36,13 +36,15 @@ public class ShadowStepBranch extends AbstractUpgradeBranch<ShadowStep> {
                 "Shadow Step - Master Upgrade",
                 """
                         +10% Cooldown Reduction
+                        +1 Max Charges
                         
-                        Instead of leaping forward gain 75% damage resistance and instantly dash forward +12 blocks dealing damage to enemies passed through.
+                        Instead of leaping forward gain 75% damage resistance and instantly dash forward 8 blocks dealing damage to enemies passed through.
                         For every enemy hit, increase your crit chance and crit multiplier by 2% for 5s (Max 20%).
                         """,
                 50000,
                 () -> {
                     ability.getCooldown().addMultiplicativeModifierMult("Shadow Dash", 0.9f);
+                    ability.setMaxCharges(2);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/earthwarden/EarthlivingWeaponBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/earthwarden/EarthlivingWeaponBranch.java
@@ -5,6 +5,10 @@ import com.ebicep.warlords.pve.upgrades.*;
 
 public class EarthlivingWeaponBranch extends AbstractUpgradeBranch<EarthlivingWeapon> {
 
+    @Override
+    public void runOnce() {
+        ability.setRadius(8);
+    }
     int weaponDamage = ability.getWeaponDamage();
     int maxHits = ability.getMaxHits();
 

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/LightningBoltBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/LightningBoltBranch.java
@@ -54,13 +54,15 @@ public class LightningBoltBranch extends AbstractUpgradeBranch<LightningBolt> {
                 "Electric Bolt",
                 "Lightning Bolt - Master Upgrade",
                 """
-                        -10 Energy cost
+                        +10 Energy cost
+                        +1 Block Radius
                         
-                        The first target hit takes 35% more damage enemies hit afterwards take 15% more damage.
+                        The first target hit takes 60% more damage, each subsequent enemy hit increases damage by an additional 15%.
                         """,
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -10);
+                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", 10);
+                    ability.getHitBoxRadius().addAdditiveModifier("Master Upgrade Branch", 1);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/berserker/BerserkBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/berserker/BerserkBranch.java
@@ -48,12 +48,12 @@ public class BerserkBranch extends AbstractUpgradeBranch<Berserk> {
                 "Maniacal Rage",
                 "Berserk - Master Upgrade",
                 """
-                        +10% Additional damage increase
+                        +20% Additional damage increase
 
-                        Gain 0.5% Crit chance and Crit Multiplier for each instance of damage you deal to an enemy while Berserk is active. (Max 60%)""",
+                        Gain 1% Crit chance and Crit Multiplier for each instance of damage you deal to an enemy while Berserk is active. (Max 60%)""",
                 50000,
                 () -> {
-                    ability.setDamageIncrease(ability.getDamageIncrease() + 10);
+                    ability.setDamageIncrease(ability.getDamageIncrease() + 20);
 
                 }
         );
@@ -61,7 +61,7 @@ public class BerserkBranch extends AbstractUpgradeBranch<Berserk> {
                 "Visceral Rage",
                 "Berserk - Master Upgrade",
                 """
-                        While Berserk is active, all damage you deal will stack up (max 20,000 damage). You may recast Berserk to convert all dealt damage into 0.5% energy and unleash a massive shockwave dealing 30% damage. The re-cast has unlimited uses.
+                        While Berserk is active, all damage you deal will stack up (max 50,000 damage). You may recast Berserk to convert all dealt damage into 0.2% energy and unleash a massive shockwave dealing 15% damage. The re-cast has unlimited uses.
                         """,
                 50000,
                 () -> {

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/revenant/RecklessChargeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/revenant/RecklessChargeBranch.java
@@ -62,7 +62,7 @@ public class RecklessChargeBranch extends AbstractUpgradeBranch<RecklessCharge> 
                         +80% damage reduction on cast.
                         +3 Block distance.
                         
-                        Additionally, allies you charge through receive 100% more healing for 8 seconds and have their active timers increased by 2 seconds.
+                        Additionally, allies you charge through receive 50% more healing for 8 seconds and have their active timers increased by 2 seconds.
                         """,
                 50000,
                 () -> {

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryBastion.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryBastion.java
@@ -1,34 +1,25 @@
 package com.ebicep.warlords.pve.weapons.weapontypes.legendaries.titles;
 
-import com.ebicep.warlords.effects.EffectUtils;
 import com.ebicep.warlords.events.player.ingame.WarlordsDamageHealingEvent;
 import com.ebicep.warlords.game.option.pve.PveOption;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
-import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendaryWeapon;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
-import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.PassiveCounter;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.Effect;
 import org.bukkit.Location;
-import org.bukkit.Particle;
-import org.bukkit.World;
 import org.springframework.data.annotation.Transient;
-
-import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 public class LegendaryBastion extends AbstractLegendaryWeapon {
 
@@ -92,7 +83,7 @@ public class LegendaryBastion extends AbstractLegendaryWeapon {
                 null,
                 player,
                 CooldownTypes.WEAPON,
-                cm -> {},
+                cooldownManager -> {},
                 false
         ));
 
@@ -143,7 +134,7 @@ public class LegendaryBastion extends AbstractLegendaryWeapon {
                 null,
                 ally,
                 CooldownTypes.WEAPON,
-                cm -> {},
+                cooldownManager -> {},
                 false
         ) {
             @Override
@@ -165,11 +156,10 @@ public class LegendaryBastion extends AbstractLegendaryWeapon {
                     double redirectCapRemain = Math.max(0.0, owner.getMaxHealth() * (getRedirectCapPercent() / 100.0) - redirectUsedThisSecond);
                     double toRedirect = Math.min(redirectCapRemain, prevented * (REDIRECT_RATIO_PERCENT / 100.0));
                     if (toRedirect > 0) {
-                        WarlordsEntity src = event.getSource() != null ? event.getSource() : ally;
                         owner.addInstance(InstanceBuilder
                                 .damage()
                                 .cause("Bastion")
-                                .source(src)
+                                .source(ally)
                                 .min((float) toRedirect)
                                 .max((float) toRedirect)
                                 .flags(InstanceFlags.RECURSIVE, InstanceFlags.REFLECTIVE_DAMAGE, InstanceFlags.IGNORE_DAMAGE_BOOST)
@@ -177,7 +167,6 @@ public class LegendaryBastion extends AbstractLegendaryWeapon {
                         redirectUsedThisSecond += toRedirect;
                     }
                 }
-
                 return reduced;
             }
         });


### PR DESCRIPTION
Pyromancer
    • Fireball
        ◦ Damage branch scales up to 60% damage
        ◦ Energy branch scales up to -20 energy
    • Time warp m2
        ◦ Warp duration -2s
        ◦ Cooldown reduction on kill 0.75s -> 2s
    • Inferno
        ◦ Crit Damage branch scales up to 80%
        ◦ Duration branch scales up to 8s

Berserker
    • M1 Berserk
        ◦ Additional damage increase 10% -> 20%
        ◦ Increased crit chance/multiplier per hit 0.5% -> 1%
    • M2 Berserk
        ◦ 20k damage -> 50k damage
        ◦ 40% conversion -> 15% conversion
        ◦ 0.5% energy -> 0.2% energy
          
Revenant
    • M2 Reckless Charge
        ◦ Healing increase 100% -> 50%

Thunderlord
    • M2 Lightning Bolt (reworked)
        ◦ Damage now scales with each enemy hit
        ◦ First hit +60% damage
        ◦ +15% damage every other hit

Earthwarden
    • Earthliving Weapon 
        ◦ Radius 3 -> 4

Assassin
    • M1 Shadow Step
        ◦ Removed extra curse cast on landing
        ◦ Shadow step will now be able to hit same mob twice on cast and land
    • M2 Shadow Step (reworked)
        ◦ Teleport range 12 -> 8 blocks
        ◦ Reduced vertical movement
        ◦ Hit radius 2 -> 3.5
        ◦ +1 charge
    • M1 Order of Eviscerate 
        ◦ Backstab damage 70% -> 120%

Apothecary
    • Leech cap 500 -> 300 but now scales with leech stacks (up to 1200)

Conjurer
    • Contagious facade now gives 3 phex stacks
    • M1 Contagious Facade
        ◦ Eps boost 5s -> 8s
    • M2 Contagious Facade (reworked slightly)
        ◦ +20% absorb damage
        ◦ Now increases shield health by 2.5x instead of absorb damage
        ◦ Remove max hp cap