### PR TITLE
feat: multi level modifiers

### DIFF
--- a/src/main/java/com/ebicep/warlords/abilities/ArcaneShield.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ArcaneShield.java
@@ -74,7 +74,9 @@ public class ArcaneShield extends AbstractAbility implements BlueAbilityIcon, Du
                     return;
                 }
                 AbstractAbility rightClick = abilities.get(0);
-                FloatModifiable.FloatModifier modifier = rightClick.getEnergyCost().addMultiplicativeModifierAdd("Arcane Energy", -.25f);
+                FloatModifiable.FloatModifier modifier = rightClick.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                        "Arcane Energy", -.25f
+                );
                 wp.updateItem(rightClick);
                 wp.getCooldownManager()
                   .addCooldown(new RegularCooldown<>("Arcane Energy", "ARC", ArcaneShield.class, new ArcaneShield(), wp, CooldownTypes.ABILITY, cooldownManager2 -> {

--- a/src/main/java/com/ebicep/warlords/abilities/AstralPlague.java
+++ b/src/main/java/com/ebicep/warlords/abilities/AstralPlague.java
@@ -63,7 +63,9 @@ public class AstralPlague extends AbstractAbility implements OrangeAbilityIcon, 
         if (pveMasterUpgrade2) {
             modifiers = wp.getAbilitiesMatching(SoulfireBeam.class)
                           .stream()
-                          .map(soulfireBeam -> soulfireBeam.getCooldown().addMultiplicativeModifierMult(name + " Master", 0.6f))
+                          .map(soulfireBeam -> soulfireBeam.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                  name + " Master", 0.6f
+                          ))
                           .toList();
         } else {
             modifiers = Collections.emptyList();
@@ -105,7 +107,7 @@ public class AstralPlague extends AbstractAbility implements OrangeAbilityIcon, 
                         if (!(event.getAbility() instanceof SoulfireBeam soulfireBeam)) {
                             return;
                         }
-                        event.getCritChance().addOverridingModifier(name, 100);
+                        event.getCritChance().addModifier(FloatModifiable.ModifierType.OVERRIDING, name, 100);
                         PoisonousHex fromHex = PoisonousHex.getFromHex(wp);
                         if (new CooldownFilter<>(victim, RegularCooldown.class).filterCooldownClass(PoisonousHex.class).stream().count() < fromHex.getMaxStacks()) {
                             return;
@@ -146,15 +148,15 @@ public class AstralPlague extends AbstractAbility implements OrangeAbilityIcon, 
             }
         }.addModifier(Modifier.MODIFY_OUTGOING_CRIT_MULTIPLIER, (event, currentCritMultiplier) -> {
                     if (pveMasterUpgrade) {
-                        currentCritMultiplier.addAdditiveModifier(name, 60);
+                        currentCritMultiplier.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, 60);
                     }
                 }
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (inPve && event.getCause().equals("Poisonous Hex") && event.getFlags().contains(InstanceFlags.DOT)) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 5.0f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 5.0f);
                     }
                     if (pveMasterUpgrade2 && event.getCause().equals("Soulfire Beam")) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 1.7f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1.7f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/abilities/AvengersWrath.java
+++ b/src/main/java/com/ebicep/warlords/abilities/AvengersWrath.java
@@ -16,6 +16,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.paladin.avenger.AvengersWrathBranch;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Particle;
@@ -126,7 +127,10 @@ public class AvengersWrath extends AbstractAbility implements OrangeAbilityIcon,
                     }
                 }
         );
-        wrathCooldown.addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier(name, energyPerSecond / 20f));
+        wrathCooldown.addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                        name, energyPerSecond / 20f
+                )
+        );
         wp.getCooldownManager().addCooldown(wrathCooldown);
         return true;
     }

--- a/src/main/java/com/ebicep/warlords/abilities/Berserk.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Berserk.java
@@ -8,15 +8,16 @@ import com.ebicep.warlords.effects.FallingBlockWaveEffect;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
-import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
+import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.warrior.berserker.BerserkBranch;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
@@ -83,7 +84,7 @@ public class Berserk extends AbstractAbility implements OrangeAbilityIcon, Durat
                             return;
                         }
                         float critBoost = (1f * multiplier.get());
-                        currentCritChance.addAdditiveModifier(name, Math.min(60, critBoost));
+                        currentCritChance.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, Math.min(60, critBoost));
                     }
                 }
         );
@@ -93,7 +94,7 @@ public class Berserk extends AbstractAbility implements OrangeAbilityIcon, Durat
                             return;
                         }
                         float critBoost = (1f * multiplier.get());
-                        currentCritMultiplier.addAdditiveModifier(name, Math.min(60, critBoost));
+                        currentCritMultiplier.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, Math.min(60, critBoost));
 
                     }
                 }
@@ -101,7 +102,7 @@ public class Berserk extends AbstractAbility implements OrangeAbilityIcon, Durat
         berserkCooldown.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamgeValue) -> {
                     stats.hitsDoneAmplified++;
                     multiplier.getAndIncrement();
-                    currentDamgeValue.addMultiplicativeModifierAdd(name, damageIncrease / 100);
+            currentDamgeValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, name, damageIncrease / 100);
                 }
         );
         wp.getCooldownManager().addCooldown(berserkCooldown);

--- a/src/main/java/com/ebicep/warlords/abilities/BloodLust.java
+++ b/src/main/java/com/ebicep/warlords/abilities/BloodLust.java
@@ -18,6 +18,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.warrior.berserker.BloodlustBranch;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Color;
 import org.bukkit.Particle;
@@ -160,7 +161,7 @@ public class BloodLust extends AbstractAbility implements BlueAbilityIcon, Durat
                         }
                     } else if (pveMasterUpgrade2) {
                         if (cooldownManager.hasCooldownFromName("Bleed")) {
-                            currentDamageValue.addMultiplicativeModifierMult("Blood Thirsty", 1.3f);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Blood Thirsty", 1.3f);
                         }
                     }
                 }

--- a/src/main/java/com/ebicep/warlords/abilities/CapacitorTotem.java
+++ b/src/main/java/com/ebicep/warlords/abilities/CapacitorTotem.java
@@ -14,6 +14,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.shaman.thunderlord.CapacitorTotemBranch;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.ArmorStand;
@@ -73,7 +74,7 @@ public class CapacitorTotem extends AbstractTotem implements Duration, Damages<C
                     if (!pveMasterUpgrade2) {
                         return;
                     }
-                    currentDamageValue.addMultiplicativeModifierMult(name, Math.max(.85f, 1 - (data.playersHit * .01f)));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, Math.max(.85f, 1 - (data.playersHit * .01f)));
                 }
         );
         data.pulseDamage = () -> {

--- a/src/main/java/com/ebicep/warlords/abilities/ChainHeal.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ChainHeal.java
@@ -17,6 +17,7 @@ import com.ebicep.warlords.util.bukkit.LocationUtils;
 import com.ebicep.warlords.util.bukkit.packets.PacketUtils;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -87,7 +88,10 @@ public class ChainHeal extends AbstractChain<ChainHeal, ChainHeal.ChainHealStats
                             EffectUtils.playParticleLinkAnimation(warlordsEntity.getLocation(), wp.getLocation(), Particle.HAPPY_VILLAGER, 1, 1.25, -1);
                             EffectUtils.displayParticle(Particle.HAPPY_VILLAGER, warlordsEntity.getLocation().add(0, 1.2, 0), 4, 0.5, 0.3, 0.5, 0.01);
                         })
-                ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier("Chains of Blessings", 0.5f)));
+                ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                                "Chains of Blessings", 0.5f
+                        )
+                ));
             }
         }
         return hitCounter;
@@ -185,13 +189,13 @@ public class ChainHeal extends AbstractChain<ChainHeal, ChainHeal.ChainHealStats
                     if (event.getCause().isEmpty() || event.getCause().equals("Time Warp")) {
                         return;
                     }
-                    currentCritChance.addAdditiveModifier(name, 20);
+            currentCritChance.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, 20);
                 }
         ).addModifier(Modifier.MODIFY_OUTGOING_CRIT_MULTIPLIER, (event, currentCritMultiplier) -> {
                     if (event.getCause().isEmpty() || event.getCause().equals("Time Warp")) {
                         return;
                     }
-                    currentCritMultiplier.addAdditiveModifier(name, 40);
+            currentCritMultiplier.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, 40);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/abilities/ChainLightning.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ChainLightning.java
@@ -52,7 +52,7 @@ public class ChainLightning extends AbstractChain<ChainLightning, ChainLightning
                 })
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                     if (event.getSource().equals(giver)) {
-                        currentDamageValue.addMultiplicativeModifierMult("Aftershock", 1.3f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Aftershock", 1.3f);
                     }
                 }
         ).addModifier(Modifier.ON_ENEMY_DEATH, (event, currentDamageValue, isCrit, isKiller) -> {
@@ -123,7 +123,7 @@ public class ChainLightning extends AbstractChain<ChainLightning, ChainLightning
                 cooldownManager -> {},
                 damageReductionTickDuration
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(name,
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                             convertToDivisionDecimal(Math.min(hitCounter * damageReductionPerBounce.getCalculatedValue(), maxDamageReduction.getCalculatedValue()))
                     );
                 }

--- a/src/main/java/com/ebicep/warlords/abilities/Clairvoyance.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Clairvoyance.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -61,8 +62,8 @@ public class Clairvoyance extends AbstractAbility implements PurpleAbilityIcon, 
 
                 })
         ).addModifier(Modifier.MODIFY_OUTGOING_HEALING, (event, currentHealValue) -> {
-            currentHealValue.addMultiplicativeModifierMult(
-                    name,
+            currentHealValue.addModifier(
+                    FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                     convertToMultiplicationDecimal(healingIncreasePercent),
                     contribution -> stats.healingIncreased += Math.abs(contribution)
             );

--- a/src/main/java/com/ebicep/warlords/abilities/ConsecrateAvenger.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ConsecrateAvenger.java
@@ -19,6 +19,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.paladin.avenger.ConsecrateBranchAvenger;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -82,7 +83,7 @@ public class ConsecrateAvenger extends AbstractConsecrate implements Damages<Con
                     }
                     event.getFlags().add(InstanceFlags.STRIKE_IN_CONS);
                     addStrikesBoosted();
-                    currentDamageValue.addMultiplicativeModifierMult(name, convertToMultiplicationDecimal(strikeDamageBoost));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToMultiplicationDecimal(strikeDamageBoost));
                 }
         ));
         return true;

--- a/src/main/java/com/ebicep/warlords/abilities/ConsecrateCrusader.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ConsecrateCrusader.java
@@ -19,6 +19,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.paladin.crusader.ConsecrateBranchCrusader;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -82,7 +83,7 @@ public class ConsecrateCrusader extends AbstractConsecrate implements Damages<Co
                     }
                     event.getFlags().add(InstanceFlags.STRIKE_IN_CONS);
                     addStrikesBoosted();
-                    currentDamageValue.addMultiplicativeModifierMult(name, convertToMultiplicationDecimal(strikeDamageBoost));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToMultiplicationDecimal(strikeDamageBoost));
                 }
         ));
         return true;

--- a/src/main/java/com/ebicep/warlords/abilities/ConsecrateProtector.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ConsecrateProtector.java
@@ -16,6 +16,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.paladin.protector.ConsecrateBranchProtector;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -86,7 +87,7 @@ public class ConsecrateProtector extends AbstractConsecrate implements CanReduce
                     }
                     event.getFlags().add(InstanceFlags.STRIKE_IN_CONS);
                     addStrikesBoosted();
-                    currentDamageValue.addMultiplicativeModifierMult(name, convertToMultiplicationDecimal(strikeDamageBoost));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToMultiplicationDecimal(strikeDamageBoost));
                 }
         ));
         return true;

--- a/src/main/java/com/ebicep/warlords/abilities/ContagiousFacade.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ContagiousFacade.java
@@ -125,8 +125,8 @@ public class ContagiousFacade extends AbstractAbility implements BlueAbilityIcon
                 })
         );
         protectiveLayerCooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-            currentDamageValue.addMultiplicativeModifierMult(
-                    name,
+            currentDamageValue.addModifier(
+                    FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                     convertToDivisionDecimal(damageAbsorption.getCalculatedValue()),
                     contribution -> totalAbsorbed.addAndGet(Math.abs(contribution))
             );
@@ -229,7 +229,7 @@ public class ContagiousFacade extends AbstractAbility implements BlueAbilityIcon
                     cooldownManager -> {
                     },
                     20 * 8
-            ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier(name, 0.5f)));
+            ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, 0.5f)));
         }
         stats.timesReactivated++;
     }

--- a/src/main/java/com/ebicep/warlords/abilities/CripplingStrike.java
+++ b/src/main/java/com/ebicep/warlords/abilities/CripplingStrike.java
@@ -14,6 +14,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.warrior.revenant.CripplingStrikeBranch;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
@@ -62,8 +63,8 @@ public class CripplingStrike extends AbstractStrike<CripplingStrike, CripplingSt
                 return new PlayerNameData(Component.text("CRIP", NamedTextColor.RED), we -> we == from || (we.isTeammate(target) && we.getSpecClass().specType == SpecType.HEALER));
             }
         }.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-            currentDamageValue.addMultiplicativeModifierMult(
-                    name,
+            currentDamageValue.addModifier(
+                    FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                     crippleAmount,
                     contribution -> {
                         if (cripplingStrike != null) {

--- a/src/main/java/com/ebicep/warlords/abilities/DeathsDebt.java
+++ b/src/main/java/com/ebicep/warlords/abilities/DeathsDebt.java
@@ -18,6 +18,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.shaman.spiritguard.DeathsDebtBranch;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
@@ -146,10 +147,13 @@ public class DeathsDebt extends AbstractTotem implements Duration, AbilityStats<
                                     5 * 20
                             );
                             deathParadeCooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                                        currentDamageValue.addMultiplicativeModifierMult(name, finalDamageReduction);
+                                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, finalDamageReduction);
                                     }
                             );
-                            deathParadeCooldown.addModifier(Modifier.ENERGY_GAIN_PER_HIT, energyGainPerTick -> energyGainPerTick.addAdditiveModifier("Death Parade", 30));
+                            deathParadeCooldown.addModifier(Modifier.ENERGY_GAIN_PER_HIT, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                                            "Death Parade", 30
+                                    )
+                            );
                             wp.getCooldownManager().addCooldown(deathParadeCooldown);
                         }
                         if (over5000DamageInstances.get() >= 5) {

--- a/src/main/java/com/ebicep/warlords/abilities/DivineBlessing.java
+++ b/src/main/java/com/ebicep/warlords/abilities/DivineBlessing.java
@@ -79,7 +79,12 @@ public class DivineBlessing extends AbstractAbility implements OrangeAbilityIcon
         int maxStacks = MercifulHex.getFromHex(wp).getMaxStacks();
         List<FloatModifiable.FloatModifier> modifiers;
         if (pveMasterUpgrade2) {
-            modifiers = wp.getAbilitiesMatching(RayOfLight.class).stream().map(ability -> ability.getCooldown().addMultiplicativeModifierMult(name + " Master", 0.55f)).toList();
+            modifiers = wp.getAbilitiesMatching(RayOfLight.class)
+                          .stream()
+                          .map(ability -> ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                  name + " Master", 0.55f
+                          ))
+                          .toList();
         } else {
             modifiers = Collections.emptyList();
         }
@@ -130,8 +135,8 @@ public class DivineBlessing extends AbstractAbility implements OrangeAbilityIcon
                                                 },
                                                 21
                                         ).addModifier(Modifier.MODIFY_INCOMING_HEALING, (event, currentHealValue) -> {
-                                            currentHealValue.addMultiplicativeModifierMult(
-                                                    name,
+                                            currentHealValue.addModifier(
+                                                    FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                                                     convertToMultiplicationDecimal(hexHealingBonus),
                                                     contribution -> stats.healingIncreased += Math.abs(contribution)
                                             );
@@ -160,8 +165,8 @@ public class DivineBlessing extends AbstractAbility implements OrangeAbilityIcon
             }
         }.addModifier(Modifier.MODIFY_INCOMING_HEALING, (event, currentHealValue) -> {
                     if (new CooldownFilter<>(wp, RegularCooldown.class).filterCooldownFrom(wp).filterCooldownClass(MercifulHex.class).stream().count() >= maxStacks) {
-                        currentHealValue.addMultiplicativeModifierMult(
-                                name,
+                        currentHealValue.addModifier(
+                                FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                                 convertToMultiplicationDecimal(hexHealingBonus),
                                 contribution -> stats.healingIncreased += Math.abs(contribution)
                         );

--- a/src/main/java/com/ebicep/warlords/abilities/DrainingMiasma.java
+++ b/src/main/java/com/ebicep/warlords/abilities/DrainingMiasma.java
@@ -19,6 +19,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.rogue.apothecary.DrainingMiasmaBranch;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.*;
 import org.bukkit.entity.Player;
@@ -143,7 +144,7 @@ public class DrainingMiasma extends AbstractAbility implements OrangeAbilityIcon
                             },
                             true
                     ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                currentDamageValue.addMultiplicativeModifierMult(name, 0.75f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.75f);
                             }
                     ));
                 }

--- a/src/main/java/com/ebicep/warlords/abilities/EarthlivingWeapon.java
+++ b/src/main/java/com/ebicep/warlords/abilities/EarthlivingWeapon.java
@@ -18,6 +18,7 @@ import com.ebicep.warlords.pve.upgrades.shaman.earthwarden.EarthlivingWeaponBran
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.Particle;
@@ -89,7 +90,10 @@ public class EarthlivingWeapon extends AbstractAbility implements PurpleAbilityI
                 }
         );
         if (pveMasterUpgrade2) {
-            earthlivingCooldown.addModifier(Modifier.ENERGY_GAIN_PER_HIT, energyGainPerTick -> energyGainPerTick.addAdditiveModifier(name, 10f));
+            earthlivingCooldown.addModifier(Modifier.ENERGY_GAIN_PER_HIT, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                            name, 10f
+                    )
+            );
         }
         wp.getCooldownManager().addCooldown(earthlivingCooldown);
         return true;

--- a/src/main/java/com/ebicep/warlords/abilities/FallenSouls.java
+++ b/src/main/java/com/ebicep/warlords/abilities/FallenSouls.java
@@ -20,6 +20,7 @@ import com.ebicep.warlords.util.bukkit.EntitiesUtils;
 import com.ebicep.warlords.util.bukkit.LocationBuilder;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
@@ -164,7 +165,7 @@ public class FallenSouls extends AbstractPiercingProjectile<FallenSouls, FallenS
                         cooldownManager -> {},
                         false
                 ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult(name, soulFeast.getDamageMultiplier());
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, soulFeast.getDamageMultiplier());
                         }
                 ));
             }

--- a/src/main/java/com/ebicep/warlords/abilities/Fireball.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Fireball.java
@@ -177,7 +177,7 @@ public class Fireball extends AbstractProjectile<Fireball, Fireball.FireballStat
                     }
                 })
         ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult("Burn", 1.15f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Burn", 1.15f);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/abilities/FortifyingHex.java
+++ b/src/main/java/com/ebicep/warlords/abilities/FortifyingHex.java
@@ -93,8 +93,8 @@ public class FortifyingHex extends AbstractPiercingProjectile<FortifyingHex, For
             }
         };
         cd.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-            currentDamageValue.addMultiplicativeModifierAdd(
-                    hexName + " " + Integer.toHexString(cd.hashCode()),
+            currentDamageValue.addModifier(
+                    FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, hexName + " " + Integer.toHexString(cd.hashCode()),
                     -data.damageReduction * (event.getWarlordsEntity().hasFlag() ? data.damageReductionFlagMultiplier : 1) / 100f,
                     contribution -> fromHex.getAbilityStats().damageReduced += Math.abs(contribution)
                     );
@@ -262,7 +262,7 @@ public class FortifyingHex extends AbstractPiercingProjectile<FortifyingHex, For
                         },
                         6 * 20
                 ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult("Weakening Hex", (1 + 0.05f * data.getStacks()));
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Weakening Hex", (1 + 0.05f * data.getStacks()));
                         }
                 ));
             }

--- a/src/main/java/com/ebicep/warlords/abilities/FreezingBreath.java
+++ b/src/main/java/com/ebicep/warlords/abilities/FreezingBreath.java
@@ -16,6 +16,7 @@ import com.ebicep.warlords.util.bukkit.LocationBuilder;
 import com.ebicep.warlords.util.bukkit.LocationUtils;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -215,7 +216,7 @@ public class FreezingBreath extends AbstractProjectile<FreezingBreath, FreezingB
             ).addModifier(
                     Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE,
                     (event, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 0.6f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.6f);
                     }
             ));
         }
@@ -227,7 +228,7 @@ public class FreezingBreath extends AbstractProjectile<FreezingBreath, FreezingB
         we.getCooldownManager().addCooldown(new RegularCooldown<>(name, "FRZ RES", FreezingBreath.class, new FreezingBreath(), we, CooldownTypes.BUFF, cooldownManager -> {
         }, 4 * 20
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(name, (1 - (0.05f * counter)));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, (1 - (0.05f * counter)));
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/abilities/FrostBolt.java
+++ b/src/main/java/com/ebicep/warlords/abilities/FrostBolt.java
@@ -211,7 +211,7 @@ public class FrostBolt extends AbstractPiercingProjectile<FrostBolt, FrostBolt.F
                 },
                 3 * 20
         ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(name, 1.08f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1.08f);
                 }
         ));
         hit(projectile, shooter, toReduceBy, stats.getTargetsHit(), hit);

--- a/src/main/java/com/ebicep/warlords/abilities/GroundSlamBerserker.java
+++ b/src/main/java/com/ebicep/warlords/abilities/GroundSlamBerserker.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.warrior.berserker.GroundSlamBranchBerserker;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 import java.util.Set;
@@ -46,7 +47,7 @@ public class GroundSlamBerserker extends AbstractGroundSlam implements Damages<G
               .addCooldown(new RegularCooldown<>("Reverberation", "REVERB", GroundSlamBerserker.class, new GroundSlamBerserker(), wp, CooldownTypes.BUFF, cooldownManager -> {
               }, 5 * 20
               ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                          currentDamageValue.addMultiplicativeModifierMult(name, damageBoost);
+                  currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, damageBoost);
                       }
               ));
         }

--- a/src/main/java/com/ebicep/warlords/abilities/GroundSlamDefender.java
+++ b/src/main/java/com/ebicep/warlords/abilities/GroundSlamDefender.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.warrior.defender.GroundSlamBranchDefender;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 import java.util.Set;
@@ -54,7 +55,7 @@ public class GroundSlamDefender extends AbstractGroundSlam implements Damages<Gr
                       },
                       5 * 20
               ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                          currentDamageValue.addMultiplicativeModifierMult(name, damageReduction);
+                  currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, damageReduction);
                       }
               ));
         }

--- a/src/main/java/com/ebicep/warlords/abilities/GroundSlamRevenant.java
+++ b/src/main/java/com/ebicep/warlords/abilities/GroundSlamRevenant.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.warrior.revenant.GroundSlamBranchRevenant;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 import java.util.Set;
@@ -49,7 +50,7 @@ public class GroundSlamRevenant extends AbstractGroundSlam implements Damages<Gr
                     },
                     5 * 20
             ).addModifier(Modifier.MODIFY_OUTGOING_HEALING, (event, currentHealValue) -> {
-                        currentHealValue.addMultiplicativeModifierMult(name, healingBoost);
+                currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, healingBoost);
                     }
             ));
         }

--- a/src/main/java/com/ebicep/warlords/abilities/HammerOfLight.java
+++ b/src/main/java/com/ebicep/warlords/abilities/HammerOfLight.java
@@ -280,7 +280,7 @@ public class HammerOfLight extends AbstractAbility implements OrangeAbilityIcon,
                     hammerOfLightCooldown.setNameAbbreviation("CROWN");
                     // prot strike energy reduction
                     for (ProtectorsStrike protectorsStrike : wp.getAbilitiesMatching(ProtectorsStrike.class)) {
-                        protectorsStrike.getEnergyCost().addAdditiveModifier("Hammer of Light", -crownEnergyReduction);
+                        protectorsStrike.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Hammer of Light", -crownEnergyReduction);
                     }
                     if (pveMasterUpgrade) {
                         pulseHeal(wp, 20, 1.5, data);
@@ -359,7 +359,7 @@ public class HammerOfLight extends AbstractAbility implements OrangeAbilityIcon,
                 },
                 20
         ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult("Hammer of Disillusion", 1.15f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Hammer of Disillusion", 1.15f);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/abilities/Haze.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Haze.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -88,7 +89,9 @@ public class Haze extends AbstractAbility implements OrangeAbilityIcon, Damages<
                                             },
                                             vulnerableTickDuration
                                     ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                                currentDamageValue.addMultiplicativeModifierMult("Vulernable", convertToMultiplicationDecimal(vulnerableDamageBonus));
+                                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                                "Vulernable", convertToMultiplicationDecimal(vulnerableDamageBonus)
+                                        );
                                             }
                                     ));
                                 });
@@ -124,7 +127,7 @@ public class Haze extends AbstractAbility implements OrangeAbilityIcon, Damages<
                     if (!data.vanished) {
                         return;
                     }
-                    currentDamageValue.addMultiplicativeModifierMult(name, convertToDivisionDecimal(incomingDamageReduction));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToDivisionDecimal(incomingDamageReduction));
                 }
         );
         hazeCooldown.addModifier(Modifier.ON_OUTGOING_DAMAGE, (event, currentDamageValue, isCrit) -> {

--- a/src/main/java/com/ebicep/warlords/abilities/HealingRain.java
+++ b/src/main/java/com/ebicep/warlords/abilities/HealingRain.java
@@ -192,7 +192,10 @@ public class HealingRain extends AbstractAbility implements OrangeAbilityIcon, D
                                         cooldownManager -> {
                                         },
                                         10
-                                ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier("Nimbus", 0.25f)));
+                                ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                                                "Nimbus", 0.25f
+                                        )
+                                ));
                             }
                         } else {
                             for (WarlordsEntity teammateInRain : teammatesInRain) {

--- a/src/main/java/com/ebicep/warlords/abilities/HealingTotem.java
+++ b/src/main/java/com/ebicep/warlords/abilities/HealingTotem.java
@@ -173,7 +173,7 @@ public class HealingTotem extends AbstractTotem implements Duration, HitBox, Hea
                                              cooldownManager -> {
                                              }, 20
                                      ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                                 currentDamageValue.addMultiplicativeModifierMult(name, 0.5f);
+                                         currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.5f);
                                              }
                                      ));
                             });
@@ -227,7 +227,7 @@ public class HealingTotem extends AbstractTotem implements Duration, HitBox, Hea
                              .addCooldown(new RegularCooldown<>("Totem Crippling", "CRIP", HealingTotemData.class, data, wp, CooldownTypes.LOW_LEVEL_DEBUFF, cooldownManager -> {
                              }, crippleDuration * 20
                              ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                         currentDamageValue.addMultiplicativeModifierMult(name, 0.75f);
+                                 currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.75f);
                                      }
                              ));
                         });

--- a/src/main/java/com/ebicep/warlords/abilities/HeartToHeart.java
+++ b/src/main/java/com/ebicep/warlords/abilities/HeartToHeart.java
@@ -183,7 +183,7 @@ public class HeartToHeart extends AbstractAbility implements PurpleAbilityIcon, 
                                   },
                                   6 * 20
                           ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                                      currentDamageValue.addMultiplicativeModifierMult(name, damageMultiplier);
+                              currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, damageMultiplier);
                                   }
                           ));
                     }

--- a/src/main/java/com/ebicep/warlords/abilities/HolyRadianceAvenger.java
+++ b/src/main/java/com/ebicep/warlords/abilities/HolyRadianceAvenger.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.pve.upgrades.paladin.avenger.HolyRadianceBranchAvenge
 import com.ebicep.warlords.util.bukkit.LocationUtils;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
@@ -115,7 +116,9 @@ public class HolyRadianceAvenger extends AbstractHolyRadiance implements Heals<H
                         EffectUtils.playCylinderAnimation(markTarget.getLocation(), 1, 250, 25, 25, 8, 6, .3);
                     }
                 })
-        ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier("Avenger's Mark", -energyDrainPerSecond / 20f)));
+        ).addModifier(Modifier.ENERGY_GAIN_PER_TICK,
+                energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE, "Avenger's Mark", -energyDrainPerSecond / 20f)
+        ));
     }
 
     private void aoeMark(WarlordsEntity giver, WarlordsEntity target) {
@@ -140,15 +143,15 @@ public class HolyRadianceAvenger extends AbstractHolyRadiance implements Heals<H
                 })
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (pveMasterUpgrade) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 0.9f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.9f);
                     }
                 }
         ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (pveMasterUpgrade && event.getCause().equals("Avenger's Strike")) {
-                        currentDamageValue.addMultiplicativeModifierMult("Avenger's Mark", 1.4f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Avenger's Mark", 1.4f);
                     }
                     if (pveMasterUpgrade2) {
-                        currentDamageValue.addMultiplicativeModifierMult("Avenger's Mark", 1.2f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Avenger's Mark", 1.2f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/abilities/HolyRadianceCrusader.java
+++ b/src/main/java/com/ebicep/warlords/abilities/HolyRadianceCrusader.java
@@ -4,11 +4,9 @@ import com.ebicep.warlords.abilities.internal.*;
 import com.ebicep.warlords.database.repositories.config.ConfigManager;
 import com.ebicep.warlords.effects.EffectUtils;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
-import com.ebicep.warlords.player.ingame.WarlordsNPC;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
-import com.ebicep.warlords.pve.mobs.flags.NoTargetAbilities;
 import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.paladin.crusader.HolyRadianceBranchCrusader;
@@ -72,7 +70,7 @@ public class HolyRadianceCrusader extends AbstractHolyRadiance implements Heals<
             List<FloatModifiable.FloatModifier> modifiers = new ArrayList<>();
             if (pveMasterUpgrade2) {
                 for (AbstractAbility ability : markTarget.getAbilities()) {
-                    modifiers.add(ability.getEnergyCost().addAdditiveModifier("Unrivalled Radiance", -10));
+                    modifiers.add(ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Unrivalled Radiance", -10));
                 }
             }
             markTarget.addSpeedModifier(wp, "Crusader Mark Speed", markSpeed, 20 * markDuration);
@@ -96,7 +94,10 @@ public class HolyRadianceCrusader extends AbstractHolyRadiance implements Heals<
                             EffectUtils.playCylinderAnimation(markTarget.getLocation(), 1, 255, 170, 0, 8, 3, .3);
                         }
                     })
-            ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier("Crusader's Mark", energyPerSecond / 20f)));
+            ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                            "Crusader's Mark", energyPerSecond / 20f
+                    )
+            ));
             wp.sendMessage(WarlordsEntity.GIVE_ARROW_GREEN.append(Component.text(" Your ", NamedTextColor.GRAY))
                                                           .append(Component.text("Crusader's Mark", NamedTextColor.YELLOW))
                                                           .append(Component.text(" marked " + markTarget.getName() + "!", NamedTextColor.GRAY)));

--- a/src/main/java/com/ebicep/warlords/abilities/HolyRadianceProtector.java
+++ b/src/main/java/com/ebicep/warlords/abilities/HolyRadianceProtector.java
@@ -127,7 +127,7 @@ public class HolyRadianceProtector extends AbstractHolyRadiance implements Heals
                     }
                 })
         ).addModifier(Modifier.MODIFY_INCOMING_HEALING, (event, currentHealValue) -> {
-                    currentHealValue.addMultiplicativeModifierMult(name, convertToMultiplicationDecimal(markBonusHealing));
+            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToMultiplicationDecimal(markBonusHealing));
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/abilities/IceBarrier.java
+++ b/src/main/java/com/ebicep/warlords/abilities/IceBarrier.java
@@ -16,6 +16,7 @@ import com.ebicep.warlords.util.bukkit.LocationBuilder;
 import com.ebicep.warlords.util.bukkit.LocationUtils;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -89,7 +90,9 @@ public class IceBarrier extends AbstractAbility implements OrangeAbilityIcon, Du
                                                     },
                                                     ticksLeft
                                             ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                                        currentDamageValue.addMultiplicativeModifierMult("Ice Wall", 1.35f);
+                                                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                                        "Ice Wall", 1.35f
+                                                );
                                                     }
                                             ));
                                         });
@@ -129,7 +132,7 @@ public class IceBarrier extends AbstractAbility implements OrangeAbilityIcon, Du
                     if (pveMasterUpgrade2) {
                         return;
                     }
-                    currentDamageValue.addMultiplicativeModifierMult(name, getDamageReduction());
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, getDamageReduction());
                 }
         );
         wp.getCooldownManager().addCooldown(iceBarrierCooldown);

--- a/src/main/java/com/ebicep/warlords/abilities/IncendiaryCurse.java
+++ b/src/main/java/com/ebicep/warlords/abilities/IncendiaryCurse.java
@@ -148,7 +148,7 @@ public class IncendiaryCurse extends AbstractAbility implements RedAbilityIcon, 
                         },
                         5 * 20
                 ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult(name, 1.3f);
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1.3f);
                         }
                 ));
             } else if (pveMasterUpgrade2) {

--- a/src/main/java/com/ebicep/warlords/abilities/Inferno.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Inferno.java
@@ -56,7 +56,9 @@ public class Inferno extends AbstractAbility implements OrangeAbilityIcon, Durat
         List<FloatModifiable.FloatModifier> modifiers;
         if (pveMasterUpgrade) {
             wp.getCooldownManager().removeCooldown(Inferno.class, false);
-            modifiers = wp.getAbilitiesMatching(Fireball.class).stream().map(ability -> ability.getEnergyCost().addAdditiveModifier(name + " Master", -5)).toList();
+            modifiers = wp.getAbilitiesMatching(Fireball.class).stream().map(ability -> ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                    name + " Master", -5
+            )).toList();
         } else {
             modifiers = Collections.emptyList();
         }
@@ -97,9 +99,9 @@ public class Inferno extends AbstractAbility implements OrangeAbilityIcon, Durat
                 WarlordsEntity hit = event.getWarlordsEntity();
                 int oldHitCount = hitCount.computeIfAbsent(hit, k -> 0);
                 hitCount.put(hit, oldHitCount + 1);
-                currentDamageValue.addMultiplicativeModifierMult(name, convertToMultiplicationDecimal(Math.min(50, 5 * oldHitCount)));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToMultiplicationDecimal(Math.min(50, 5 * oldHitCount)));
             } else if (pveMasterUpgrade2) {
-                currentDamageValue.addMultiplicativeModifierMult(name, 1.2f);
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1.2f);
             }
                 }
         ).addModifier(Modifier.MODIFY_OUTGOING_CRIT_CHANCE, (event, currentCritChance) -> {
@@ -107,14 +109,14 @@ public class Inferno extends AbstractAbility implements OrangeAbilityIcon, Durat
                         return;
                     }
                     stats.hitsAmplified++;
-                    currentCritChance.addAdditiveModifier(name, critChanceIncrease);
+            currentCritChance.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, critChanceIncrease);
                 }
         ).addModifier(Modifier.MODIFY_OUTGOING_CRIT_MULTIPLIER, (event, currentCritMultiplier) -> {
                     if (event.getCause().isEmpty()) {
                         return;
                     }
                     stats.hitsAmplified++;
-                    currentCritMultiplier.addAdditiveModifier(name, critMultiplierIncrease);
+            currentCritMultiplier.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, critMultiplierIncrease);
                 }
         ).addModifier(Modifier.MODIFY_OUTGOING_DAMAGE_BEFORE_VARIABLE_SET, event -> {
                     if (pveMasterUpgrade2 && event.getCause().equals("Ignite")) {

--- a/src/main/java/com/ebicep/warlords/abilities/InspiringPresence.java
+++ b/src/main/java/com/ebicep/warlords/abilities/InspiringPresence.java
@@ -95,7 +95,7 @@ public class InspiringPresence extends AbstractAbility implements OrangeAbilityI
         presenceCooldown.addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> {
                     float energy = energyPerSecond / 20f;
                     data.addEnergyGivenFromStrikeAndPresence(energy);
-                    energyGainPerTick.addAdditiveModifier(name, energy);
+            energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, energy);
                 }
         );
         wp.getCooldownManager().addCooldown(presenceCooldown);
@@ -117,7 +117,9 @@ public class InspiringPresence extends AbstractAbility implements OrangeAbilityI
             presenceTarget.addSpeedModifier(wp, name, speedBuff, tickDuration);
             List<FloatModifiable.FloatModifier> modifiers;
             if (pveMasterUpgrade) {
-                modifiers = presenceTarget.getAbilities().stream().map(ability -> ability.getCooldown().addMultiplicativeModifierMult(name + " Master", 0.8f)).toList();
+                modifiers = presenceTarget.getAbilities().stream().map(ability -> ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        name + " Master", 0.8f
+                )).toList();
             } else {
                 modifiers = Collections.emptyList();
             }
@@ -140,7 +142,7 @@ public class InspiringPresence extends AbstractAbility implements OrangeAbilityI
             ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> {
                         float energy = energyPerSecond / 20f;
                         data.addEnergyGivenFromStrikeAndPresence(energy);
-                        energyGainPerTick.addAdditiveModifier(name, energy);
+                energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, energy);
                     }
             ));
         }

--- a/src/main/java/com/ebicep/warlords/abilities/Intervene.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Intervene.java
@@ -16,6 +16,7 @@ import com.ebicep.warlords.pve.upgrades.warrior.defender.InterveneBranch;
 import com.ebicep.warlords.util.java.NumberFormat;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
@@ -160,7 +161,9 @@ public class Intervene extends AbstractAbility implements BlueAbilityIcon, Durat
             wp.getCooldownManager().addCooldown(new RegularCooldown<>(name + " Damage", null, InterveneData.class, null, wp, CooldownTypes.BUFF, cooldownManager -> {
             }, tickDuration
             ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(name, (float) (1 + venes.stream().mapToDouble(InterveneData::getDamagePrevented).sum() / 100 * .01));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        name, (float) (1 + venes.stream().mapToDouble(InterveneData::getDamagePrevented).sum() / 100 * .01)
+                );
                     }
             ));
         }

--- a/src/main/java/com/ebicep/warlords/abilities/LastStand.java
+++ b/src/main/java/com/ebicep/warlords/abilities/LastStand.java
@@ -69,11 +69,11 @@ public class LastStand extends AbstractAbility implements OrangeAbilityIcon, Dur
         List<FloatModifiable.FloatModifier> modifiers = new ArrayList<>();
         if (pveMasterUpgrade2) {
             for (SeismicWaveDefender ability : wp.getAbilitiesMatching(SeismicWaveDefender.class)) {
-                modifiers.add(ability.getCooldown().addMultiplicativeModifierAdd("Enduring Defense", -.5f));
-                modifiers.add(ability.getEnergyCost().addOverridingModifier("Enduring Defense", 30f));
+                modifiers.add(ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Enduring Defense", -.5f));
+                modifiers.add(ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.OVERRIDING, "Enduring Defense", 30f));
             }
             for (GroundSlamDefender ability : wp.getAbilitiesMatching(GroundSlamDefender.class)) {
-                modifiers.add(ability.getCooldown().addMultiplicativeModifierAdd("Enduring Defense", -.5f));
+                modifiers.add(ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Enduring Defense", -.5f));
             }
         }
         RegularCooldown<LastStandData> lastStandCooldown = new RegularCooldown<>(
@@ -104,8 +104,8 @@ public class LastStand extends AbstractAbility implements OrangeAbilityIcon, Dur
                 })
         );
         lastStandCooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-            currentDamageValue.addMultiplicativeModifierMult(
-                    name,
+            currentDamageValue.addModifier(
+                    FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                     convertToDivisionDecimal(selfDamageReductionPercent),
                     contribution -> data.addAmountPrevented(Math.abs(contribution))
             );
@@ -138,8 +138,8 @@ public class LastStand extends AbstractAbility implements OrangeAbilityIcon, Dur
                         );
                     }
             ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                currentDamageValue.addMultiplicativeModifierMult(
-                        name,
+                currentDamageValue.addModifier(
+                        FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                         convertToDivisionDecimal(teammateDamageReductionPercent),
                         contribution -> data.addAmountPrevented(Math.abs(contribution))
                 );

--- a/src/main/java/com/ebicep/warlords/abilities/LightInfusionAvenger.java
+++ b/src/main/java/com/ebicep/warlords/abilities/LightInfusionAvenger.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.paladin.avenger.LightInfusionBranchAvenger;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 
@@ -64,8 +65,8 @@ public class LightInfusionAvenger extends AbstractLightInfusion {
                 }
         );
         if (pveMasterUpgrade2) {
-            infusionCooldown.addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier(name, 0.5f));
-            infusionCooldown.addModifier(Modifier.ENERGY_GAIN_PER_HIT, energyGainPerTick -> energyGainPerTick.addAdditiveModifier(name, 20));
+            infusionCooldown.addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, 0.5f));
+            infusionCooldown.addModifier(Modifier.ENERGY_GAIN_PER_HIT, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, 20));
         }
         wp.getCooldownManager().addCooldown(infusionCooldown);
         playCastEffect(wp);

--- a/src/main/java/com/ebicep/warlords/abilities/LightInfusionProtector.java
+++ b/src/main/java/com/ebicep/warlords/abilities/LightInfusionProtector.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.paladin.protector.LightInfusionBranchProtector;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Particle;
 import org.bukkit.event.Listener;
 
@@ -60,7 +61,7 @@ public class LightInfusionProtector extends AbstractLightInfusion {
                     })
             );
             ornamentOfLightCooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 0.1f);
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.1f);
                     }
             );
             wp.addKnockbackModifier(wp, "Ornament of Light", -50, ornamentOfLightCooldown);
@@ -78,7 +79,7 @@ public class LightInfusionProtector extends AbstractLightInfusion {
                     tickDuration
             ).addModifier(Modifier.MODIFY_OUTGOING_HEALING, (event, currentHealValue) -> {
                         if (event.getCause().equals("Protector's Strike")) {
-                            currentHealValue.addMultiplicativeModifierMult("Chiron Light", 1.25f);
+                            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Chiron Light", 1.25f);
                         }
                     }
             ));

--- a/src/main/java/com/ebicep/warlords/abilities/LightningRod.java
+++ b/src/main/java/com/ebicep/warlords/abilities/LightningRod.java
@@ -151,7 +151,7 @@ public class LightningRod extends AbstractAbility implements BlueAbilityIcon, He
         we.getCooldownManager().addCooldown(new RegularCooldown<>(name, "ROD DMG", LightningRod.class, new LightningRod(), we, CooldownTypes.ABILITY, cooldownManager -> {
         }, 12 * 20
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(name, 1.2f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1.2f);
                 }
         ));
     }
@@ -163,7 +163,9 @@ public class LightningRod extends AbstractAbility implements BlueAbilityIcon, He
         from.getCooldownManager().removeCooldownByName("Call of Thunder Buff");
         List<FloatModifiable.FloatModifier> modifiers;
         if (pveMasterUpgrade2) {
-            modifiers = from.getAbilitiesMatching(ChainLightning.class).stream().map(ability -> ability.getEnergyCost().addAdditiveModifier("Call of Thunder Buff", -25)).toList();
+            modifiers = from.getAbilitiesMatching(ChainLightning.class).stream().map(ability -> ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                    "Call of Thunder Buff", -25
+            )).toList();
         } else {
             modifiers = Collections.emptyList();
         }
@@ -181,7 +183,7 @@ public class LightningRod extends AbstractAbility implements BlueAbilityIcon, He
                     modifiers.forEach(FloatModifiable.FloatModifier::forceEnd);
                 },
                 10 * 20
-        ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier("Call of Thunder", 15 / 20f)));
+        ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE, "Call of Thunder", 15 / 20f)));
     }
 
     @Override

--- a/src/main/java/com/ebicep/warlords/abilities/MysticalBarrier.java
+++ b/src/main/java/com/ebicep/warlords/abilities/MysticalBarrier.java
@@ -18,6 +18,7 @@ import com.ebicep.warlords.pve.upgrades.arcanist.sentinel.MysticalBarrierBranch;
 import com.ebicep.warlords.util.java.NumberFormat;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Particle;
@@ -224,7 +225,7 @@ public class MysticalBarrier extends AbstractAbility implements BlueAbilityIcon,
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                     if (event.getCause().isEmpty()) {
                         stats.meleesReduced++;
-                        currentDamageValue.addMultiplicativeModifierMult(name, convertToDivisionDecimal(meleeDamageReduction));
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToDivisionDecimal(meleeDamageReduction));
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/abilities/OrbsOfLife.java
+++ b/src/main/java/com/ebicep/warlords/abilities/OrbsOfLife.java
@@ -18,6 +18,7 @@ import com.ebicep.warlords.util.bukkit.LocationBuilder;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
@@ -163,7 +164,9 @@ public class OrbsOfLife extends AbstractAbility implements BlueAbilityIcon, Dura
         );
         orbsOfLifeCooldown.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (pveMasterUpgrade) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, convertToMultiplicationDecimal(Math.min(30f, 1f * data.spawnedOrbs.size())));
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                name, convertToMultiplicationDecimal(Math.min(30f, 1f * data.spawnedOrbs.size()))
+                        );
                     }
                 }
         );

--- a/src/main/java/com/ebicep/warlords/abilities/OrderOfEviscerate.java
+++ b/src/main/java/com/ebicep/warlords/abilities/OrderOfEviscerate.java
@@ -18,6 +18,7 @@ import com.ebicep.warlords.util.bukkit.LocationUtils;
 import com.ebicep.warlords.util.java.NumberFormat;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Particle;
@@ -119,7 +120,7 @@ public class OrderOfEviscerate extends AbstractAbility implements OrangeAbilityI
                         stats.numberOfBackstabs++;
                         damageBonus += 70;
                     }
-                    currentDamageValue.addMultiplicativeModifierMult(name, 1 + damageBonus / 100f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1 + damageBonus / 100f);
                 }
         );
         orderOfEviscerateCooldown.addModifier(Modifier.DAMAGE_BEFORE_ANY_REDUCTION_ATTACKER, event -> {
@@ -192,7 +193,9 @@ public class OrderOfEviscerate extends AbstractAbility implements OrangeAbilityI
                                                 8 * 20
                                         );
                                         regularCooldown.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                                    currentDamageValue.addMultiplicativeModifierMult(name, 1 + 0.4f * stacks.get());
+                                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                                    name, 1 + 0.4f * stacks.get()
+                                            );
                                                 }
                                         );
                                         cooldown.set(regularCooldown);

--- a/src/main/java/com/ebicep/warlords/abilities/Parry.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Parry.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.java.NumberFormat;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Sound;
@@ -145,7 +146,9 @@ public class Parry extends AbstractAbility implements AbilityStats<Parry, Parry.
                                                 }
                                     };
                                     parryCooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (e, currentDamageValue) -> {
-                                                currentDamageValue.addMultiplicativeModifierMult(name, convertToDivisionDecimal(data.instances.size() * damageReduction));
+                                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                                name, convertToDivisionDecimal(data.instances.size() * damageReduction)
+                                        );
                                             }
                                     );
                                     wp.getCooldownManager().addCooldown(parryCooldown);

--- a/src/main/java/com/ebicep/warlords/abilities/PrismGuard.java
+++ b/src/main/java/com/ebicep/warlords/abilities/PrismGuard.java
@@ -20,6 +20,7 @@ import com.ebicep.warlords.pve.upgrades.rogue.vindicator.PrismGuardBranch;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
@@ -135,8 +136,8 @@ public class PrismGuard extends AbstractAbility implements BlueAbilityIcon, Dura
                                     },
                                     tickDuration
                             ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                                currentDamageValue.addMultiplicativeModifierMult(
-                                        name,
+                                currentDamageValue.addModifier(
+                                        FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                                         convertToDivisionDecimal(damageReduction),
                                         contribution -> data.totalDamageReduced += Math.abs(contribution)
                                 );
@@ -172,7 +173,7 @@ public class PrismGuard extends AbstractAbility implements BlueAbilityIcon, Dura
                                             cooldownManager -> {},
                                             6
                                     ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                                currentDamageValue.addMultiplicativeModifierMult(name, 1.1f);
+                                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1.1f);
                                             }
                                     ));
                                 }
@@ -198,8 +199,8 @@ public class PrismGuard extends AbstractAbility implements BlueAbilityIcon, Dura
                                         if (Utils.isProjectile(event.getCause())) {
                                             if (!isInsideBubble.contains(event.getSource())) {
                                                 stats.timesProjectilesReduced++;
-                                                currentDamageValue.addMultiplicativeModifierMult(
-                                                        name,
+                                                currentDamageValue.addModifier(
+                                                        FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                                                         (100 - projectileDamageReduction) / 100f,
                                                         contribution -> data.totalDamageReduced += Math.abs(contribution)
                                                 );
@@ -239,7 +240,7 @@ public class PrismGuard extends AbstractAbility implements BlueAbilityIcon, Dura
                         }
                         if (event.getCause().isEmpty()) {
                             event.applyToMinMax(floatModifiable ->
-                                    floatModifiable.addMultiplicativeModifierMult(name, .75f)
+                                    floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, .75f)
                             );
                         }
                     }
@@ -258,8 +259,8 @@ public class PrismGuard extends AbstractAbility implements BlueAbilityIcon, Dura
                     if (pveMasterUpgrade) {
                         totalReduction += 10;
                     }
-            currentDamageValue.addMultiplicativeModifierMult(
-                    name,
+            currentDamageValue.addModifier(
+                    FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                     (100 - totalReduction) / 100f,
                     contribution -> data.totalDamageReduced += Math.abs(contribution)
             );

--- a/src/main/java/com/ebicep/warlords/abilities/RayOfLight.java
+++ b/src/main/java/com/ebicep/warlords/abilities/RayOfLight.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.arcanist.luminary.RayOfLightBranch;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -79,7 +80,7 @@ public class RayOfLight extends AbstractBeam<RayOfLight, RayOfLight.RayOfLightSt
             }, cooldownManager -> {
             }, 100
             ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(name, maxStacks ? 1.2f : 1.05f);
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, maxStacks ? 1.2f : 1.05f);
                     }
             ));
         }

--- a/src/main/java/com/ebicep/warlords/abilities/RecklessCharge.java
+++ b/src/main/java/com/ebicep/warlords/abilities/RecklessCharge.java
@@ -75,7 +75,7 @@ public class RecklessCharge extends AbstractAbility implements RedAbilityIcon, H
                       },
                       2 * 20
               ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                          currentDamageValue.addMultiplicativeModifierMult(name, 0.2f);
+                  currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.2f);
                       }
               ));
         }
@@ -177,7 +177,7 @@ public class RecklessCharge extends AbstractAbility implements RedAbilityIcon, H
                                     getStunTimeInTicks()
                             ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                                         if (event.getCause().contains("Strike")) {
-                                            currentDamageValue.addMultiplicativeModifierMult("Reckless Rampage", 1.25f);
+                                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Reckless Rampage", 1.25f);
                                         }
                                     }
                             ));
@@ -195,7 +195,7 @@ public class RecklessCharge extends AbstractAbility implements RedAbilityIcon, H
                                 },
                                 8 * 20
                         ).addModifier(Modifier.MODIFY_INCOMING_HEALING, (event, currentHealValue) -> {
-                                    currentHealValue.addMultiplicativeModifierMult(name, 1.5f);
+                            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1.5f);
                                 }
                         ));
                         new CooldownFilter<>(otherPlayer, RegularCooldown.class).filter(cd -> cd.getCooldownType() != CooldownTypes.LOW_LEVEL_DEBUFF)

--- a/src/main/java/com/ebicep/warlords/abilities/RemedicChains.java
+++ b/src/main/java/com/ebicep/warlords/abilities/RemedicChains.java
@@ -90,13 +90,13 @@ public class RemedicChains extends AbstractAbility implements BlueAbilityIcon, D
             warlordsEntity.setRegenTickTimer(1);
             float healthIncrease = warlordsEntity.getMaxHealth() * .25f;
             if (pveMasterUpgrade) {
-                healthBoosts.put(warlordsEntity, warlordsEntity.getHealth().addAdditiveModifier("Remedic Chains", healthIncrease));
+                healthBoosts.put(warlordsEntity, warlordsEntity.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Remedic Chains", healthIncrease));
                 warlordsEntity.setCurrentHealth(warlordsEntity.getCurrentHealth() + healthIncrease);
             }
         });
         if (pveMasterUpgrade) {
             float healthIncrease = wp.getMaxHealth() * .25f;
-            healthBoosts.put(wp, wp.getHealth().addAdditiveModifier("Remedic Chains", healthIncrease));
+            healthBoosts.put(wp, wp.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Remedic Chains", healthIncrease));
             wp.setCurrentHealth(wp.getCurrentHealth() + healthIncrease);
         }
         LinkedCooldown<RemedicChains> remedicChainsCooldown = new LinkedCooldown<>(name,
@@ -168,8 +168,8 @@ public class RemedicChains extends AbstractAbility implements BlueAbilityIcon, D
                 teammatesNear
         );
         remedicChainsCooldown.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addAdditiveModifier(name, damageValues.getBonusDamage().getValue());
-                    currentDamageValue.addMultiplicativeModifierMult(name, pveMasterUpgrade2 ? 1.15f : 1);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, damageValues.getBonusDamage().getValue());
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, pveMasterUpgrade2 ? 1.15f : 1);
                 }
         );
         wp.getCooldownManager().removeCooldown(RemedicChains.class, false);

--- a/src/main/java/com/ebicep/warlords/abilities/Repentance.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Repentance.java
@@ -14,6 +14,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.shaman.spiritguard.RepentanceBranch;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import com.google.common.util.concurrent.AtomicDouble;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
@@ -74,7 +75,10 @@ public class Repentance extends AbstractAbility implements BlueAbilityIcon, Dura
 
                                 },
                                 8 * 20
-                        ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier("Remembrance", energyGain)));
+                        ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                                        "Remembrance", energyGain
+                                )
+                        ));
                     }
                 },
                 tickDuration

--- a/src/main/java/com/ebicep/warlords/abilities/SanctifiedBeacon.java
+++ b/src/main/java/com/ebicep/warlords/abilities/SanctifiedBeacon.java
@@ -20,6 +20,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.arcanist.luminary.SanctifiedBeaconBranch;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.*;
@@ -139,7 +140,7 @@ public class SanctifiedBeacon extends AbstractBeaconAbility<SanctifiedBeacon, Sa
                             6
                     );
                     shadowGardenCooldown.addModifier(Modifier.MODIFY_OUTGOING_CRIT_MULTIPLIER, (event, currentCritMultiplier) -> {
-                                currentCritMultiplier.addAdditiveModifier("Shadow Garden", 30);
+                        currentCritMultiplier.addModifier(FloatModifiable.ModifierType.ADDITIVE, "Shadow Garden", 30);
                             }
                     );
                     nearBy.addKnockbackModifier(wp, "Shadow Garden", -50, shadowGardenCooldown);
@@ -165,15 +166,15 @@ public class SanctifiedBeacon extends AbstractBeaconAbility<SanctifiedBeacon, Sa
                             }
                     ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                                 if (crit[0]) { // TODO unscuff
-                                    currentDamageValue.addMultiplicativeModifierAdd(
-                                            name,
+                                    currentDamageValue.addModifier(
+                                            FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, name,
                                             -critMultiplierReducedBy / 100f,
                                             contribution -> stats.critDamageReduced += Math.abs(contribution)
                                     );
                                 }
                                 if (wp.isInPve()) {
-                                    currentDamageValue.addMultiplicativeModifierMult(
-                                            name,
+                                    currentDamageValue.addModifier(
+                                            FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                                             convertToDivisionDecimal(damageReductionPve)
                                     );
                                 }
@@ -197,7 +198,7 @@ public class SanctifiedBeacon extends AbstractBeaconAbility<SanctifiedBeacon, Sa
                                       cooldownManager -> {},
                                       false
                               ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                          currentDamageValue.addMultiplicativeModifierMult(name, 0.7f);
+                                  currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.7f);
                                       }
                               ));
                     }

--- a/src/main/java/com/ebicep/warlords/abilities/Sanctuary.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Sanctuary.java
@@ -64,7 +64,12 @@ public class Sanctuary extends AbstractAbility implements OrangeAbilityIcon, Dur
         EffectUtils.playCircularShieldAnimation(loc, Particle.DRIPPING_WATER, 3, 0.6, 1.2);
         List<FloatModifiable.FloatModifier> modifiers;
         if (pveMasterUpgrade2) {
-            modifiers = wp.getAbilitiesMatching(GuardianBeam.class).stream().map(ability -> ability.getCooldown().addMultiplicativeModifierMult(name + " Master", 0.7f)).toList();
+            modifiers = wp.getAbilitiesMatching(GuardianBeam.class)
+                          .stream()
+                          .map(ability -> ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                  name + " Master", 0.7f
+                          ))
+                          .toList();
         } else {
             modifiers = Collections.emptyList();
         }
@@ -190,14 +195,14 @@ public class Sanctuary extends AbstractAbility implements OrangeAbilityIcon, Dur
                 if (hexStacks < maxStacks) {
                             return;
                         }
-                currentDamageValue.addMultiplicativeModifierAdd(
-                        name,
+                currentDamageValue.addModifier(
+                        FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, name,
                         -additionalDamageReduction * maxStacks / 100f,
                         contribution -> stats.damageReduced += Math.abs(contribution)
                 );
                 if (pveMasterUpgrade) {
-                    currentDamageValue.addMultiplicativeModifierMult(
-                            name,
+                    currentDamageValue.addModifier(
+                            FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                             .85f,
                             contribution -> stats.damageReduced += Math.abs(contribution)
                     );

--- a/src/main/java/com/ebicep/warlords/abilities/ShadowStep.java
+++ b/src/main/java/com/ebicep/warlords/abilities/ShadowStep.java
@@ -16,6 +16,7 @@ import com.ebicep.warlords.util.bukkit.LocationBuilder;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -124,7 +125,7 @@ public class ShadowStep extends AbstractAbility implements
                 },
                 2
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(name, .25f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, .25f);
                 }
         ));
         Set<WarlordsEntity> hit = new HashSet<>();
@@ -172,10 +173,14 @@ public class ShadowStep extends AbstractAbility implements
                     cooldownManager -> {},
                     5 * 20
             ).addModifier(Modifier.MODIFY_OUTGOING_CRIT_CHANCE, (event, currentCritChance) -> {
-                        currentCritChance.addMultiplicativeModifierMult("Shadow Dash CC", convertToMultiplicationDecimal(Math.min(2f * hit.size(), 20)));
+                currentCritChance.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        "Shadow Dash CC", convertToMultiplicationDecimal(Math.min(2f * hit.size(), 20))
+                );
                     }
             ).addModifier(Modifier.MODIFY_OUTGOING_CRIT_MULTIPLIER, (event, currentCritMultiplier) -> {
-                currentCritMultiplier.addMultiplicativeModifierMult("Shadow Dash CC", convertToMultiplicationDecimal(Math.min(2f * hit.size(), 20)));
+                currentCritMultiplier.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        "Shadow Dash CC", convertToMultiplicationDecimal(Math.min(2f * hit.size(), 20))
+                );
                     }
             ));
         }

--- a/src/main/java/com/ebicep/warlords/abilities/Solitary.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Solitary.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.bukkit.LocationUtils;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
@@ -65,7 +66,7 @@ public class Solitary extends AbstractAbility implements OrangeAbilityIcon, Dura
                 },
                 tickDuration
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(name, convertToDivisionDecimal(damageReduction));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToDivisionDecimal(damageReduction));
                 }
         ));
         for (Intervene intervene : wp.getAbilitiesMatching(Intervene.class)) {

--- a/src/main/java/com/ebicep/warlords/abilities/SoothingElixir.java
+++ b/src/main/java/com/ebicep/warlords/abilities/SoothingElixir.java
@@ -165,7 +165,7 @@ public class SoothingElixir extends AbstractAbility implements RedAbilityIcon, D
                     }
                     if (pveMasterUpgrade2) {
                         float healthBoost = (float) (wp.getMaxHealth() * Math.max(.25, (teammatesHit.size() + enemiesHit.size()) * .015f));
-                        wp.getHealth().addAdditiveModifier("Soothing Elixir", healthBoost, 4 * 20);
+                        wp.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Soothing Elixir", healthBoost, 4 * 20);
                         wp.setCurrentHealth(wp.getCurrentHealth() + healthBoost);
                     }
                 }

--- a/src/main/java/com/ebicep/warlords/abilities/SoulShackle.java
+++ b/src/main/java/com/ebicep/warlords/abilities/SoulShackle.java
@@ -16,6 +16,7 @@ import com.ebicep.warlords.pve.upgrades.rogue.vindicator.SoulShackleBranch;
 import com.ebicep.warlords.util.bukkit.LocationBuilder;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.title.Title;
@@ -163,7 +164,7 @@ public class SoulShackle extends AbstractAbility implements RedAbilityIcon, Dama
                     },
                     3 * 20
             ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult("Oppressive Chains", 1.25f);
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Oppressive Chains", 1.25f);
                     }
             ));
         }

--- a/src/main/java/com/ebicep/warlords/abilities/SoulSwitch.java
+++ b/src/main/java/com/ebicep/warlords/abilities/SoulSwitch.java
@@ -134,7 +134,7 @@ public class SoulSwitch extends AbstractAbility implements BlueAbilityIcon, HitB
                     cooldownManager -> {},
                     damageReductionTickDuration
             ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(name, convertToDivisionDecimal(damageReduction));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToDivisionDecimal(damageReduction));
                     }
             ));
             if (swapTarget instanceof WarlordsNPC npc) {
@@ -175,7 +175,7 @@ public class SoulSwitch extends AbstractAbility implements BlueAbilityIcon, HitB
 
                                 })
                         ).addModifier(Modifier.MODIFY_OUTGOING_CRIT_CHANCE, (event, currentCritChance) -> {
-                                    currentCritChance.addAdditiveModifier("Tricky Switch", 15);
+                            currentCritChance.addModifier(FloatModifiable.ModifierType.ADDITIVE, "Tricky Switch", 15);
                                 }
                         ));
                     }
@@ -199,7 +199,7 @@ public class SoulSwitch extends AbstractAbility implements BlueAbilityIcon, HitB
                             }
                         })
                 ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult(name, 0.5f);
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.5f);
                         }
                 ));
 

--- a/src/main/java/com/ebicep/warlords/abilities/Soulbinding.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Soulbinding.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.shaman.spiritguard.SoulbindingWeaponBranch;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
@@ -129,7 +130,7 @@ public class Soulbinding extends AbstractAbility implements PurpleAbilityIcon, D
                 soulbinding -> soulbinding.getSoulBindedPlayers().isEmpty(),
                 Collections.singletonList((cooldown, ticksLeft, ticksElapsed) -> {
                     if (ticksElapsed == 1) {
-                        this.energyCost.addOverridingModifier("Soulbinding Reactivation", 0, tickDuration);
+                        this.energyCost.addModifier(FloatModifiable.ModifierType.OVERRIDING, "Soulbinding Reactivation", 0, tickDuration);
                     }
                     if (ticksElapsed % 4 == 0) {
                         Location location = wp.getLocation();

--- a/src/main/java/com/ebicep/warlords/abilities/SpiritLink.java
+++ b/src/main/java/com/ebicep/warlords/abilities/SpiritLink.java
@@ -17,6 +17,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.shaman.spiritguard.SpiritLinkBranch;
 import com.ebicep.warlords.util.bukkit.LocationUtils;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.Particle;
@@ -97,7 +98,7 @@ public class SpiritLink extends AbstractChain<SpiritLink, SpiritLink.SpiritLinkS
                 },
                 (int) (damageReductionDuration * 20)
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(name, 1 - damageReduction / 100f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1 - damageReduction / 100f);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/abilities/SuperBrew.java
+++ b/src/main/java/com/ebicep/warlords/abilities/SuperBrew.java
@@ -87,10 +87,11 @@ public class SuperBrew extends AbstractAbility implements OrangeAbilityIcon, Hit
 
         target.setRegenTickTimer(tickDuration);
         List<FloatModifiable.FloatModifier> modifiers = new ArrayList<>();
-        modifiers.add(target.getEnergyPerSec().addAdditiveModifier(name, energyPerSecondIncrease));
-        modifiers.add(target.getEnergy().addAdditiveModifier(name, maxEnergyIncrease));
+        modifiers.add(target.getEnergyPerSec().addModifier(FloatModifiable.ModifierType.ADDITIVE, name, energyPerSecondIncrease));
+        modifiers.add(target.getEnergy().addModifier(FloatModifiable.ModifierType.ADDITIVE, name, maxEnergyIncrease));
         for (AbstractAbility ability : target.getAbilitiesImplementing(OrangeAbilityIcon.class)) {
-            modifiers.add(ability.getCooldownReductionPerTick().addMultiplicativeModifierMult(name, 100f / (100 - ultCooldownReductionPercent))); // 20% = 1.25
+            modifiers.add(ability.getCooldownReductionPerTick()
+                                 .addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 100f / (100 - ultCooldownReductionPercent))); // 20% = 1.25
         }
         SuperBrewData data = new SuperBrewData(this);
         target.getCooldownManager().removeCooldown(SuperBrewData.class, false);
@@ -136,13 +137,16 @@ public class SuperBrew extends AbstractAbility implements OrangeAbilityIcon, Hit
         );
         superBrewCooldown.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (event.getCause().isEmpty() && event.getSource().equals(target)) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, AbstractAbility.convertToMultiplicationDecimal(meleeDamageIncreasePercent));
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                name,
+                                AbstractAbility.convertToMultiplicationDecimal(meleeDamageIncreasePercent)
+                        );
                     }
                 }
         );
         superBrewCooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                     if (event.getCause().isEmpty() && event.getWarlordsEntity().equals(target)) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, convertToDivisionDecimal(meleeDamageTakenDecreasePercent));
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToDivisionDecimal(meleeDamageTakenDecreasePercent));
                     }
                 }
         );

--- a/src/main/java/com/ebicep/warlords/abilities/TimeWarpAquamancer.java
+++ b/src/main/java/com/ebicep/warlords/abilities/TimeWarpAquamancer.java
@@ -16,6 +16,7 @@ import com.ebicep.warlords.util.bukkit.LocationBuilder;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
@@ -86,7 +87,7 @@ public class TimeWarpAquamancer extends AbstractTimeWarp {
                                 },
                                 5 * 20
                         ).addModifier(Modifier.MODIFY_OUTGOING_HEALING, (event, currentHealValue) -> {
-                                    currentHealValue.addMultiplicativeModifierMult(name, 1.15f);
+                            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1.15f);
                                 }
                         ));
                     }

--- a/src/main/java/com/ebicep/warlords/abilities/TimeWarpCryomancer.java
+++ b/src/main/java/com/ebicep/warlords/abilities/TimeWarpCryomancer.java
@@ -21,6 +21,7 @@ import com.ebicep.warlords.pve.upgrades.mage.cryomancer.TimeWarpBranchCryomancer
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.PlayerFilterGeneric;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -90,7 +91,7 @@ public class TimeWarpCryomancer extends AbstractTimeWarp {
                             },
                             duration
                     ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                currentDamageValue.addMultiplicativeModifierMult("Freezing Cold", 1.15f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Freezing Cold", 1.15f);
                             }
                     ));
                 });
@@ -128,7 +129,7 @@ public class TimeWarpCryomancer extends AbstractTimeWarp {
                                   Collections.singletonList((cooldown, ticksLeft, ticksElapsed) -> {
                                   })
                           ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                                      currentDamageValue.addMultiplicativeModifierMult(name, .2f);
+                              currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, .2f);
                                   }
                           ));
                     }

--- a/src/main/java/com/ebicep/warlords/abilities/TimeWarpPyromancer.java
+++ b/src/main/java/com/ebicep/warlords/abilities/TimeWarpPyromancer.java
@@ -18,6 +18,7 @@ import com.ebicep.warlords.pve.upgrades.mage.pyromancer.TimeWarpBranchPyromancer
 import com.ebicep.warlords.util.bukkit.LocationBuilder;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.minecraft.sounds.SoundSource;
 import org.bukkit.Instrument;
 import org.bukkit.Location;
@@ -161,7 +162,9 @@ public class TimeWarpPyromancer extends AbstractTimeWarp {
         );
         damageBoost.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (pveMasterUpgrade) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, convertToMultiplicationDecimal(0.75f * (we.getBlocksTravelled() - startingBlocksTravelled)));
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                name, convertToMultiplicationDecimal(0.75f * (we.getBlocksTravelled() - startingBlocksTravelled))
+                        );
                     }
                 }
         );

--- a/src/main/java/com/ebicep/warlords/abilities/Triage.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Triage.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Particle;
@@ -93,8 +94,8 @@ public class Triage extends AbstractAbility implements PurpleAbilityIcon, Listen
                 bonusHealingDurationTicks
         ).addModifier(Modifier.MODIFY_OUTGOING_HEALING, (event, currentHealValue) -> {
                     if (event.getWarlordsEntity() == lastFlagCarrier) {
-                        currentHealValue.addMultiplicativeModifierMult(
-                                name,
+                        currentHealValue.addModifier(
+                                FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name,
                                 convertToMultiplicationDecimal(targetBonusHealing),
                                 contribution -> stats.healingIncreased += Math.abs(contribution)
                         );

--- a/src/main/java/com/ebicep/warlords/abilities/UndyingArmy.java
+++ b/src/main/java/com/ebicep/warlords/abilities/UndyingArmy.java
@@ -123,8 +123,14 @@ public class UndyingArmy extends AbstractAbility implements OrangeAbilityIcon, D
         UndyingArmyData data = getArmyData(wp);
         List<FloatModifiable.FloatModifier> modifiers = new ArrayList<>();
         if (pveMasterUpgrade) {
-            wp.doOnStaticAbility(RecklessCharge.class, ability -> modifiers.add(ability.getCooldown().addMultiplicativeModifierAdd("Relentless Army", -.5f)));
-            wp.doOnStaticAbility(GroundSlamRevenant.class, ability -> modifiers.add(ability.getCooldown().addMultiplicativeModifierAdd("Relentless Army", -.5f)));
+            wp.doOnStaticAbility(RecklessCharge.class, ability -> modifiers.add(ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                            "Relentless Army", -.5f
+                    ))
+            );
+            wp.doOnStaticAbility(GroundSlamRevenant.class, ability -> modifiers.add(ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                            "Relentless Army", -.5f
+                    ))
+            );
         }
         int numberOfPlayersWithArmy = 0;
         for (WarlordsEntity teammate : PlayerFilter

--- a/src/main/java/com/ebicep/warlords/abilities/Vindicate.java
+++ b/src/main/java/com/ebicep/warlords/abilities/Vindicate.java
@@ -18,6 +18,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.rogue.vindicator.VindicateBranch;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Particle;
@@ -97,9 +98,9 @@ public class Vindicate extends AbstractAbility implements OrangeAbilityIcon, Dur
                                 .value(currentDamageValue.getCalculatedValue() * .75f)
                                 .flags(InstanceFlags.IGNORE_SELF_RES, InstanceFlags.RECURSIVE, InstanceFlags.REFLECTIVE_DAMAGE)
                         );
-                        currentDamageValue.addMultiplicativeModifierMult(name, .1f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, .1f);
                     } else {
-                        currentDamageValue.addMultiplicativeModifierMult(name, getCalculatedVindicateDamageReduction());
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, getCalculatedVindicateDamageReduction());
                     }
                 }
         ));
@@ -137,7 +138,7 @@ public class Vindicate extends AbstractAbility implements OrangeAbilityIcon, Dur
         };
         vindiateCooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                     if (vindPveMaster2) {
-                        currentDamageValue.addMultiplicativeModifierMult("Vindicate", .85f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Vindicate", .85f);
                     }
                 }
         );

--- a/src/main/java/com/ebicep/warlords/abilities/VitalityConcoction.java
+++ b/src/main/java/com/ebicep/warlords/abilities/VitalityConcoction.java
@@ -58,7 +58,7 @@ public class VitalityConcoction extends AbstractAbility implements PurpleAbility
         List<FloatModifiable.FloatModifier> modifiers = new ArrayList<>();
         if (pveMasterUpgrade2) {
             wp.doOnStaticAbility(ImpalingStrike.class, impalingStrike -> {
-                        modifiers.add(impalingStrike.getEnergyCost().addMultiplicativeModifierAdd("Concoction Party", -.75f));
+                modifiers.add(impalingStrike.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Concoction Party", -.75f));
                     }
             );
         }
@@ -101,7 +101,7 @@ public class VitalityConcoction extends AbstractAbility implements PurpleAbility
 
         };
         cooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(name, convertToDivisionDecimal(damageResistance));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToDivisionDecimal(damageResistance));
                 }
         );
         wp.getCooldownManager().addCooldown(cooldown);
@@ -149,7 +149,7 @@ public class VitalityConcoction extends AbstractAbility implements PurpleAbility
                     }
 
                 }.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult(name, convertToDivisionDecimal(damageResistance / 2f));
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToDivisionDecimal(damageResistance / 2f));
                         }
                 ));
                 we.addInstance(InstanceBuilder

--- a/src/main/java/com/ebicep/warlords/abilities/VitalityLiquor.java
+++ b/src/main/java/com/ebicep/warlords/abilities/VitalityLiquor.java
@@ -17,6 +17,7 @@ import com.ebicep.warlords.pve.upgrades.rogue.apothecary.VitalityLiquorBranch;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
@@ -104,7 +105,7 @@ public class VitalityLiquor extends AbstractAbility implements PurpleAbilityIcon
                                             },
                                             duration * 20
                                     ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick ->
-                                            energyGainPerTick.addAdditiveModifier("Vitality Liquor", energyPerSecond / 20f)
+                                            energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE, "Vitality Liquor", energyPerSecond / 20f)
                                     ));
                                 }
                             }

--- a/src/main/java/com/ebicep/warlords/abilities/WaterBolt.java
+++ b/src/main/java/com/ebicep/warlords/abilities/WaterBolt.java
@@ -183,7 +183,7 @@ public class WaterBolt extends AbstractProjectile<WaterBolt, WaterBolt.WaterBolt
 
                 },
                 5 * 20
-        ).addModifier(Modifier.ENERGY_GAIN_PER_HIT, energyGainPerTick -> energyGainPerTick.addAdditiveModifier(name, 6)));
+        ).addModifier(Modifier.ENERGY_GAIN_PER_HIT, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, 6)));
     }
 
     @Override

--- a/src/main/java/com/ebicep/warlords/abilities/WindfuryWeapon.java
+++ b/src/main/java/com/ebicep/warlords/abilities/WindfuryWeapon.java
@@ -19,6 +19,7 @@ import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.shaman.thunderlord.WindfuryBranch;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
@@ -136,7 +137,7 @@ public class WindfuryWeapon extends AbstractAbility implements PurpleAbilityIcon
                 }
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                     if (pveMasterUpgrade2) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, (100 - Math.min(15, procs.get() * 2.5f)) / 100f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, (100 - Math.min(15, procs.get() * 2.5f)) / 100f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/abilities/WoundingStrikeBerserker.java
+++ b/src/main/java/com/ebicep/warlords/abilities/WoundingStrikeBerserker.java
@@ -152,7 +152,7 @@ public class WoundingStrikeBerserker extends AbstractStrike<WoundingStrikeBerser
                     }
                 })
         ).addModifier(Modifier.MODIFY_INCOMING_HEALING, (event, currentHealValue) -> {
-                    currentHealValue.addMultiplicativeModifierMult(name, 0.2f);
+            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.2f);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/abilities/WoundingStrikeDefender.java
+++ b/src/main/java/com/ebicep/warlords/abilities/WoundingStrikeDefender.java
@@ -88,7 +88,7 @@ public class WoundingStrikeDefender extends AbstractStrike<WoundingStrikeDefende
                     },
                     4 * 20
             ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 0.85f);
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.85f);
                     }
             ));
             new CooldownFilter<>(wp, RegularCooldown.class)
@@ -131,7 +131,7 @@ public class WoundingStrikeDefender extends AbstractStrike<WoundingStrikeDefende
                 teammates
         );
         linkedCooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(name, .7f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, .7f);
                 }
         );
         we.getCooldownManager().removeCooldownByName(name + " Resistance");

--- a/src/main/java/com/ebicep/warlords/abilities/internal/AbstractConsecrate.java
+++ b/src/main/java/com/ebicep/warlords/abilities/internal/AbstractConsecrate.java
@@ -102,7 +102,7 @@ public abstract class AbstractConsecrate extends AbstractAbility implements RedA
                     }
                     event.getFlags().add(InstanceFlags.STRIKE_IN_CONS);
                     addStrikesBoosted();
-                    currentDamageValue.addMultiplicativeModifierMult(name, convertToMultiplicationDecimal(strikeDamageBoost));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, convertToMultiplicationDecimal(strikeDamageBoost));
                 }
         ));
 

--- a/src/main/java/com/ebicep/warlords/abilities/internal/AbstractEnergySeer.java
+++ b/src/main/java/com/ebicep/warlords/abilities/internal/AbstractEnergySeer.java
@@ -16,6 +16,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
@@ -141,13 +142,17 @@ public abstract class AbstractEnergySeer<T extends AbstractEnergySeer.EnergySeer
         };
         cd.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (inPve && AbstractEnergySeer.this instanceof EnergySeerConjurer energySeerConjurer) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, convertToMultiplicationDecimal(energySeerConjurer.getDamageIncrease()));
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                name, convertToMultiplicationDecimal(energySeerConjurer.getDamageIncrease())
+                        );
                     }
                 }
         );
         if (inPve && AbstractEnergySeer.this instanceof EnergySeerLuminary energySeerLuminary) {
             cd.addModifier(Modifier.MODIFY_INCOMING_HEALING, (event, currentHealValue) -> {
-                        currentHealValue.addMultiplicativeModifierMult(name, convertToMultiplicationDecimal(energySeerLuminary.getHealingIncrease()));
+                currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        name, convertToMultiplicationDecimal(energySeerLuminary.getHealingIncrease())
+                );
                     }
             );
         }
@@ -213,7 +218,7 @@ public abstract class AbstractEnergySeer<T extends AbstractEnergySeer.EnergySeer
                         );
                     }
                 })
-        ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier(name, -epsDecrease / 20f)));
+        ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, -epsDecrease / 20f)));
     }
 
     protected void onEndForce(WarlordsEntity wp, T data) {

--- a/src/main/java/com/ebicep/warlords/abilities/internal/WoundingCooldown.java
+++ b/src/main/java/com/ebicep/warlords/abilities/internal/WoundingCooldown.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.player.ingame.instances.type.PlayerNameInstance;
 import com.ebicep.warlords.util.java.NumberFormat;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
@@ -106,7 +107,7 @@ public class WoundingCooldown extends RegularCooldown<WoundingCooldown.WoundingD
         );
         this.target = target;
         this.addModifier(Modifier.MODIFY_INCOMING_HEALING, (event, currentHealValue) -> {
-                    currentHealValue.addMultiplicativeModifierMult(name, cooldownObject.getWoundingMultiplier());
+            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, cooldownObject.getWoundingMultiplier());
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/commands/debugcommands/game/GameDebugCommand.java
+++ b/src/main/java/com/ebicep/warlords/commands/debugcommands/game/GameDebugCommand.java
@@ -15,6 +15,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
@@ -190,7 +191,7 @@ public class GameDebugCommand extends BaseCommand {
                                             },
                                             false
                                     ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                        currentDamageValue.addMultiplicativeModifierMult(getName(), 100);
+                                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 100);
                                             }
                                     ));
                                 });

--- a/src/main/java/com/ebicep/warlords/commands/debugcommands/misc/OldTestCommand.java
+++ b/src/main/java/com/ebicep/warlords/commands/debugcommands/misc/OldTestCommand.java
@@ -1,6 +1,16 @@
 package com.ebicep.warlords.commands.debugcommands.misc;
 
+import com.ebicep.warlords.Warlords;
+import com.ebicep.warlords.abilities.internal.DamagePowerup;
+import com.ebicep.warlords.player.ingame.WarlordsEntity;
+import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
+import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
+import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
+import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
+import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.chat.ChatChannels;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.MultiFloatModifiable;
 import io.papermc.paper.command.brigadier.BasicCommand;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import org.bukkit.command.CommandSender;
@@ -14,6 +24,84 @@ public class OldTestCommand implements BasicCommand {
         if (commandSender instanceof Player player) {
             if (!player.isOp()) {
                 return;
+            }
+            WarlordsEntity warlordsEntity = Warlords.getPlayer(player);
+            if (warlordsEntity != null) {
+                RegularCooldown<DamagePowerup> cooldown = new RegularCooldown<>(
+                        "TEST",
+                        "TEST",
+                        null,
+                        null,
+                        warlordsEntity,
+                        CooldownTypes.BUFF,
+                        cooldownManager -> {
+                        },
+                        cooldownManager -> {
+                        },
+                        100
+                );
+                cooldown.addModifier(
+                        Modifier.MODIFY_OUTGOING_DAMAGE_AFTER_INTERVENE,
+                        (event, currentDamageValue) -> {
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "TEST2", 2);
+                        }
+                );
+                cooldown.addModifier(
+                        Modifier.MODIFY_OUTGOING_DAMAGE_AFTER_INTERVENE,
+                        (event, currentDamageValue) -> {
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "TEST3", 3);
+                        }
+                );
+                cooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
+                            currentDamageValue.addModifier(
+                                    FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Ice Barrier",
+                                    0.75f
+                            );
+                        }
+                );
+                cooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
+                            currentDamageValue.addModifier(
+                                    75, MultiFloatModifiable.ApplyFloatModifiableType.MULTIPLICATIVE,
+                                    FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Fortifying Hex 1",
+                                    -0.1f
+                            );
+                        }
+                );
+                cooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
+                            currentDamageValue.addModifier(
+                                    75, MultiFloatModifiable.ApplyFloatModifiableType.MULTIPLICATIVE,
+                                    FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Fortifying Hex 2",
+                                    -0.1f
+                            );
+                        }
+                );
+                cooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
+                            currentDamageValue.addModifier(
+                                    75, MultiFloatModifiable.ApplyFloatModifiableType.MULTIPLICATIVE,
+                                    FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Fortifying Hex 3",
+                                    -0.1f
+                            );
+                        }
+                );
+                cooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
+                            currentDamageValue.addModifier(
+                                    75, MultiFloatModifiable.ApplyFloatModifiableType.MULTIPLICATIVE,
+                                    FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Sanctuary",
+                                    -0.6f,
+                                    f -> {
+                                        ChatChannels.sendDebugMessage(player, "" + f);
+                                    }
+                            );
+                        }
+                );
+                warlordsEntity.getCooldownManager().addCooldown(cooldown);
+                warlordsEntity.addInstance(InstanceBuilder
+                        .damage()
+                        .cause("Test Damage")
+                        .source(warlordsEntity)
+                        .value(100)
+                        .flags(InstanceFlags.IGNORE_SELF_RES)
+                );
             }
         }
         ChatChannels.sendDebugMessage(commandSender instanceof Player player ? player : null, "Executed OldTestCommand");

--- a/src/main/java/com/ebicep/warlords/commands/debugcommands/misc/OldTestCommand.java
+++ b/src/main/java/com/ebicep/warlords/commands/debugcommands/misc/OldTestCommand.java
@@ -41,6 +41,18 @@ public class OldTestCommand implements BasicCommand {
                         100
                 );
                 cooldown.addModifier(
+                        Modifier.ON_INCOMING_SHIELD_DAMAGE,
+                        (event, currentDamageValue, isCrit) -> {
+
+                        }
+                );
+                cooldown.addModifier(
+                        Modifier.ON_OUTGOING_SHIELD_DAMAGE,
+                        (event, currentDamageValue, isCrit) -> {
+
+                        }
+                );
+                cooldown.addModifier(
                         Modifier.MODIFY_OUTGOING_DAMAGE_AFTER_INTERVENE,
                         (event, currentDamageValue) -> {
                             currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "TEST2", 2);

--- a/src/main/java/com/ebicep/warlords/game/GameAddon.java
+++ b/src/main/java/com/ebicep/warlords/game/GameAddon.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.game.state.PreLobbyState;
 import com.ebicep.warlords.game.state.State;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.util.bukkit.ItemBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
@@ -96,7 +97,9 @@ public enum GameAddon {
         @Override
         public void warlordsEntityCreated(@Nonnull Game game, @Nonnull WarlordsEntity player) {
             player.setEnergyModifier(player.getEnergyModifier() * 0.25f);
-            player.getAbilities().forEach(ability -> ability.getCooldown().addMultiplicativeModifierMult("Cooldown Mode", 0.25f));
+            player.getAbilities().forEach(ability -> ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                    "Cooldown Mode", 0.25f
+            ));
         }
     },
     TRIPLE_HEALTH(
@@ -106,7 +109,7 @@ public enum GameAddon {
     ) {
         @Override
         public void warlordsEntityCreated(@Nonnull Game game, @Nonnull WarlordsEntity player) {
-            player.getHealth().addMultiplicativeModifierAdd("Triple Health (Base)", 2f);
+            player.getHealth().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Triple Health (Base)", 2f);
             player.heal();
         }
     },

--- a/src/main/java/com/ebicep/warlords/game/maps/Acropolis.java
+++ b/src/main/java/com/ebicep/warlords/game/maps/Acropolis.java
@@ -27,6 +27,7 @@ import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.DifficultyIndex;
 import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.util.bukkit.LocationFactory;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -234,7 +235,7 @@ public class Acropolis extends GameMap {
                         },
                         false
                 ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult("Scaling", damageMultiplier);
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Scaling", damageMultiplier);
                         }
                 ));
             }

--- a/src/main/java/com/ebicep/warlords/game/maps/ForgottenCodex.java
+++ b/src/main/java/com/ebicep/warlords/game/maps/ForgottenCodex.java
@@ -28,6 +28,7 @@ import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.DifficultyIndex;
 import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.util.bukkit.LocationFactory;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -145,7 +146,7 @@ public class ForgottenCodex extends GameMap {
                         },
                         false
                 ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult("Scaling", damageMultiplier);
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Scaling", damageMultiplier);
                         }
                 ));
             }

--- a/src/main/java/com/ebicep/warlords/game/maps/GrimoiresGraveyard.java
+++ b/src/main/java/com/ebicep/warlords/game/maps/GrimoiresGraveyard.java
@@ -33,6 +33,7 @@ import com.ebicep.warlords.pve.mobs.events.libraryarchives.EventScriptedGrimoire
 import com.ebicep.warlords.pve.mobs.events.libraryarchives.EventTheArchivist;
 import com.ebicep.warlords.util.bukkit.LocationBuilder;
 import com.ebicep.warlords.util.bukkit.LocationFactory;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -333,7 +334,7 @@ public class GrimoiresGraveyard extends GameMap {
                         },
                         false
                 ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult("Scaling", damageMultiplier);
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Scaling", damageMultiplier);
                         }
                 ));
             }

--- a/src/main/java/com/ebicep/warlords/game/maps/Tartarus.java
+++ b/src/main/java/com/ebicep/warlords/game/maps/Tartarus.java
@@ -31,6 +31,7 @@ import com.ebicep.warlords.pve.DifficultyIndex;
 import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.util.bukkit.LocationFactory;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.trait.SkinTrait;
 import net.kyori.adventure.text.Component;
@@ -212,7 +213,7 @@ public class Tartarus extends GameMap {
                         },
                         false
                 ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult("Scaling", damageMultiplier);
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Scaling", damageMultiplier);
                         }
                 ));
             }

--- a/src/main/java/com/ebicep/warlords/game/option/PowerupOption.java
+++ b/src/main/java/com/ebicep/warlords/game/option/PowerupOption.java
@@ -332,7 +332,10 @@ public class PowerupOption implements Option {
                             we.sendMessage(getWornOffMessage());
                         },
                         getTickDuration()
-                ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier("Energy Powerup", 0.5f)));
+                ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                                "Energy Powerup", 0.5f
+                        )
+                ));
                 we.sendMessage(Component.text("You activated the ", NamedTextColor.GOLD)
                                         .append(Component.text("ENERGY", NamedTextColor.GOLD, TextDecoration.BOLD))
                                         .append(Component.text(" powerup! "))
@@ -366,7 +369,7 @@ public class PowerupOption implements Option {
                         },
                         getTickDuration()
                 ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult("Damage", 1.2f);
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Damage", 1.2f);
                         }
                 ));
                 we.sendMessage(Component.text("You activated the ", NamedTextColor.GOLD)
@@ -390,7 +393,9 @@ public class PowerupOption implements Option {
                 we.getCooldownManager().removeCooldown(CooldownPowerup.class, false);
                 List<FloatModifiable.FloatModifier> modifiers = we.getAbilities()
                                                                   .stream()
-                                                                  .map(ability -> ability.getCooldown().addMultiplicativeModifierMult(name + " Powerup", 0.75f))
+                                                                  .map(ability -> ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                                                          name + " Powerup", 0.75f
+                                                                  ))
                                                                   .toList();
                 we.getCooldownManager().addCooldown(new RegularCooldown<>(
                         "Cooldown",
@@ -492,7 +497,7 @@ public class PowerupOption implements Option {
                             }
                         })
                 ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult(name, 1.1f);
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1.1f);
                         }
                 ));
                 we.sendMessage(Component.text("You activated the ", NamedTextColor.GOLD)

--- a/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/AccumulatingKnowledge.java
+++ b/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/AccumulatingKnowledge.java
@@ -8,6 +8,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
@@ -64,15 +65,15 @@ public class AccumulatingKnowledge implements FieldEffect {
                         return;
                     }
                     multiplier.set(newMultiplier);
-                    player.getHealth().addMultiplicativeModifierAdd(getName() + " (Base)", Math.min(multiplier.get(), 25) / 100f);
+                    player.getHealth().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, getName() + " (Base)", Math.min(multiplier.get(), 25) / 100f);
                 }
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     int buff = Math.min(multiplier.get(), 25);
-                    currentDamageValue.addMultiplicativeModifierMult(getName(), 1 - buff / 100f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1 - buff / 100f);
                 }
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
             int buff = Math.min(multiplier.get(), 15);
-            currentDamageValue.addMultiplicativeModifierMult(getName(), (1 - buff / 100f));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), (1 - buff / 100f));
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/Arachnophobia.java
+++ b/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/Arachnophobia.java
@@ -8,6 +8,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.pve.mobs.AbstractMob;
 import com.ebicep.warlords.pve.mobs.events.spidersburrow.EventEggSac;
 import com.ebicep.warlords.pve.mobs.events.spidersburrow.EventPoisonousSpider;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -42,12 +43,12 @@ public class Arachnophobia implements FieldEffect {
                     }
                     if (event.getCause().contains("Strike")) {
                         event.applyToMinMax(floatModifiable ->
-                                floatModifiable.addMultiplicativeModifierMult(getName(), 3)
+                                floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 3)
                         );
                     }
                 } else if (event.isHealingInstance()) {
                     event.applyToMinMax(floatModifiable ->
-                            floatModifiable.addMultiplicativeModifierMult(getName(), 1.15f)
+                            floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1.15f)
                     );
                 }
             }

--- a/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/CodexCollector.java
+++ b/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/CodexCollector.java
@@ -21,6 +21,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.pve.gameevents.libraryarchives.PlayerCodex;
 import com.ebicep.warlords.pve.mobs.events.libraryarchives.EventInquisiteur;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.event.EventHandler;
@@ -100,8 +101,8 @@ public class CodexCollector implements FieldEffect {
                     return;
                 }
                 if (event.getCause().isEmpty()) {
-                    event.getCritChance().addAdditiveModifier(getName(), 5);
-                    event.getCritMultiplier().addAdditiveModifier(getName(), 10);
+                    event.getCritChance().addModifier(FloatModifiable.ModifierType.ADDITIVE, getName(), 5);
+                    event.getCritMultiplier().addModifier(FloatModifiable.ModifierType.ADDITIVE, getName(), 10);
                 }
             }
 
@@ -143,8 +144,8 @@ public class CodexCollector implements FieldEffect {
                 for (AbstractAbility ability : player.getAbilities()) {
                     Value.applyDamageHealing(ability, value -> {
                                 if (value instanceof Value.RangedValueCritable rangedValueCritable) {
-                                    rangedValueCritable.critChance().addAdditiveModifier(getName(), 5);
-                                    rangedValueCritable.critMultiplier().addAdditiveModifier(getName(), 10);
+                                    rangedValueCritable.critChance().addModifier(FloatModifiable.ModifierType.ADDITIVE, getName(), 5);
+                                    rangedValueCritable.critMultiplier().addModifier(FloatModifiable.ModifierType.ADDITIVE, getName(), 10);
                                 }
                             }
                     );

--- a/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/ConqueringEnergy.java
+++ b/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/ConqueringEnergy.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.game.Game;
 import com.ebicep.warlords.game.option.pve.wavedefense.events.fieldeffects.FieldEffect;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -30,7 +31,7 @@ public class ConqueringEnergy implements FieldEffect {
                 }
                 if (event.getCause().isEmpty()) {
                     event.applyToMinMax(floatModifiable ->
-                            floatModifiable.addMultiplicativeModifierMult(getName(), 1.5f)
+                            floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1.5f)
                     );
                 }
             }
@@ -40,7 +41,7 @@ public class ConqueringEnergy implements FieldEffect {
 
     @Override
     public void onWarlordsEntityCreated(WarlordsEntity player) {
-        player.getEnergyPerSec().addAdditiveModifier(getName(), -10);
-        player.getEnergyPerHit().addMultiplicativeModifierAdd(getName(), 1.5f);
+        player.getEnergyPerSec().addModifier(FloatModifiable.ModifierType.ADDITIVE, getName(), -10);
+        player.getEnergyPerHit().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, getName(), 1.5f);
     }
 }

--- a/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/DumbDebuffs.java
+++ b/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/DumbDebuffs.java
@@ -7,6 +7,7 @@ import com.ebicep.warlords.player.ingame.WarlordsNPC;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class DumbDebuffs implements FieldEffect {
 
@@ -35,7 +36,7 @@ public class DumbDebuffs implements FieldEffect {
                     false
             ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                         int debuffDamageBoost = Math.min(event.getWarlordsEntity().getCooldownManager().getDebuffCooldowns(true).size(), 12);
-                        currentDamageValue.addMultiplicativeModifierMult("Dumb Debuff", (1 + (debuffDamageBoost * .15f)));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Dumb Debuff", (1 + (debuffDamageBoost * .15f)));
                     }
             ));
         }

--- a/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/TycheProsperity.java
+++ b/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/TycheProsperity.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.chat.ChatUtils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -87,12 +88,15 @@ public class TycheProsperity implements FieldEffect {
     }
 
     private void mageBonus(WarlordsEntity warlordsEntity) {
-        warlordsEntity.getEnergyPerSec().addAdditiveModifier(getName(), 5);
-        warlordsEntity.getAbilitiesMatching(AbstractPiercingProjectile.class).forEach(proj -> proj.getProjectileSpeed().addMultiplicativeModifierAdd(getName(), .1f));
+        warlordsEntity.getEnergyPerSec().addModifier(FloatModifiable.ModifierType.ADDITIVE, getName(), 5);
+        warlordsEntity.getAbilitiesMatching(AbstractPiercingProjectile.class)
+                      .forEach(proj -> proj.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                              getName(), .1f
+                      ));
     }
 
     private void paladinBonus(WarlordsEntity warlordsEntity) {
-        warlordsEntity.getEnergyPerHit().addAdditiveModifier(getName(), 5);
+        warlordsEntity.getEnergyPerHit().addModifier(FloatModifiable.ModifierType.ADDITIVE, getName(), 5);
         warlordsEntity.getSpeed().addBaseModifier(5);
     }
 
@@ -109,7 +113,7 @@ public class TycheProsperity implements FieldEffect {
                 false
         );
         warriorCooldown.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(getName(), 1.05f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1.05f);
                 }
         );
         warlordsEntity.getCooldownManager().addCooldown(warriorCooldown);
@@ -117,7 +121,7 @@ public class TycheProsperity implements FieldEffect {
     }
 
     private void shamanBonus(WarlordsEntity warlordsEntity) {
-        warlordsEntity.getHealth().addMultiplicativeModifierAdd(getName() + " (Base)", .05f);
+        warlordsEntity.getHealth().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, getName() + " (Base)", .05f);
         warlordsEntity.getCooldownManager().addCooldown(new PermanentCooldown<>(
                 getName(),
                 null,
@@ -130,14 +134,16 @@ public class TycheProsperity implements FieldEffect {
                 false
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (event.getCause().isEmpty()) {
-                        currentDamageValue.addMultiplicativeModifierMult(getName(), 1.1f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1.1f);
                     }
                 }
         ));
     }
 
     private void rogueBonus(WarlordsEntity warlordsEntity) {
-        warlordsEntity.getAbilities().forEach(ability -> ability.getCooldown().addMultiplicativeModifierMult(getName(), .9f));
+        warlordsEntity.getAbilities().forEach(ability -> ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                getName(), .9f
+        ));
         warlordsEntity.getCooldownManager().addCooldown(new PermanentCooldown<>(
                 getName(),
                 null,
@@ -149,7 +155,7 @@ public class TycheProsperity implements FieldEffect {
                 },
                 false
         ).addModifier(Modifier.MODIFY_OUTGOING_HEALING, (event, currentHealValue) -> {
-                    currentHealValue.addMultiplicativeModifierMult(getName(), 1.05f);
+            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1.05f);
                 }
         ));
     }
@@ -158,7 +164,7 @@ public class TycheProsperity implements FieldEffect {
         warlordsEntity.getAbilities().forEach(ability -> {
             Value.applyDamageHealing(ability, value -> {
                         if (value instanceof Value.RangedValueCritable rangedValueCritable) {
-                            rangedValueCritable.critChance().addAdditiveModifier(getName(), 10);
+                            rangedValueCritable.critChance().addModifier(FloatModifiable.ModifierType.ADDITIVE, getName(), 10);
                         }
                     }
             );
@@ -174,7 +180,7 @@ public class TycheProsperity implements FieldEffect {
                 },
                 false
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(getName(), .95f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), .95f);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/WarriorsTriumph.java
+++ b/src/main/java/com/ebicep/warlords/game/option/pve/wavedefense/events/fieldeffects/effects/WarriorsTriumph.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.AbstractCooldown;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.LinkedCooldown;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -57,7 +58,7 @@ public class WarriorsTriumph implements FieldEffect {
                 String ability = event.getCause();
                 if (ability.equals("Wounding Strike") || ability.equals("Crippling Strike")) {
                     event.applyToMinMax(floatModifiable ->
-                            floatModifiable.addMultiplicativeModifierMult(getName(), 3)
+                            floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 3)
                     );
                 }
             }

--- a/src/main/java/com/ebicep/warlords/game/option/pvp/FlagSpawnPointOption.java
+++ b/src/main/java/com/ebicep/warlords/game/option/pvp/FlagSpawnPointOption.java
@@ -17,6 +17,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.minecraft.world.phys.AABB;
@@ -225,7 +226,9 @@ public class FlagSpawnPointOption implements Option {
                                         },
                                         15 * 20
                                 ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                                            currentDamageValue.addMultiplicativeModifierMult("Flag Damage Resistance", AbstractAbility.convertToDivisionDecimal(flagRes));
+                                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                            "Flag Damage Resistance", AbstractAbility.convertToDivisionDecimal(flagRes)
+                                    );
                                         }
                                 ));
                             }

--- a/src/main/java/com/ebicep/warlords/game/option/pvp/siege/SiegeOption.java
+++ b/src/main/java/com/ebicep/warlords/game/option/pvp/siege/SiegeOption.java
@@ -18,6 +18,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -125,10 +126,10 @@ public class SiegeOption implements Option {
                 },
                 false
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult("Siege", 1.15f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Siege", 1.15f);
                 }
         ).addModifier(Modifier.MODIFY_OUTGOING_HEALING, (event, currentHealValue) -> {
-                    currentHealValue.addMultiplicativeModifierMult("Siege", 0.75f);
+            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Siege", 0.75f);
                 }
         ));
         for (AbstractAbility ability : player.getAbilities()) {

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/attributes/upgradeable/TowerUpgradeCategory.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/attributes/upgradeable/TowerUpgradeCategory.java
@@ -71,7 +71,7 @@ public record TowerUpgradeCategory(Component name, List<TowerUpgradeInstance> up
 
         public TowerUpgradeCategoryBuilder<T> value(String name, float value, Function<T, FloatModifiable> modifiableFunction) {
             upgradeInstances.add(new TowerUpgradeInstance.Valued(value, towerUpgradeInstance -> {
-                modifiableFunction.apply(ability).addAdditiveModifier("Upgrade", value);
+                modifiableFunction.apply(ability).addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade", value);
             }) {
                 @Override
                 public String getName() {

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/attributes/upgradeable/TowerUpgradeInstance.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/attributes/upgradeable/TowerUpgradeInstance.java
@@ -70,8 +70,8 @@ public abstract class TowerUpgradeInstance {
 
         public Damage(float value, AbstractAbility ability) {
             super(value, towerUpgradeInstance -> {
-//                ability.getMinDamageHeal().addAdditiveModifier("Upgrade", value);
-//                ability.getMaxDamageHeal().addAdditiveModifier("Upgrade", value); TODO
+//                ability.getMinDamageHeal().addModifier("Upgrade", value);
+//                ability.getMaxDamageHeal().addModifier("Upgrade", value); TODO
             });
         }
 
@@ -93,8 +93,8 @@ public abstract class TowerUpgradeInstance {
 
         public Healing(float value, AbstractAbility ability) {
             super(value, towerUpgradeInstance -> {
-//                ability.getMinDamageHeal().addAdditiveModifier("Upgrade", value);
-//                ability.getMaxDamageHeal().addAdditiveModifier("Upgrade", value);
+//                ability.getMinDamageHeal().addModifier("Upgrade", value);
+//                ability.getMaxDamageHeal().addModifier("Upgrade", value);
             });
         }
 
@@ -116,8 +116,8 @@ public abstract class TowerUpgradeInstance {
 
         public <T extends AbstractAbility & HitBox> Range(float value, T ability) {
             super(value, towerUpgradeInstance -> {
-                ability.getHitBoxRadius().addAdditiveModifier("Upgrade", value);
-                ability.getHitBoxRadius().addAdditiveModifier("Upgrade", value);
+                ability.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade", value);
+                ability.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade", value);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/mobs/TDPiglin.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/mobs/TDPiglin.java
@@ -8,6 +8,7 @@ import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.tiers.BasicMob;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 
 import java.util.Collections;
@@ -58,7 +59,7 @@ public class TDPiglin extends TowerDefenseMob implements BasicMob {
         if (!inGroup) {
             return;
         }
-        getPhysicalResistance().addAdditiveModifier("Group Bonus", 20, 11);
+        getPhysicalResistance().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Group Bonus", 20, 11);
         warlordsNPC.getCooldownManager().addCooldown(new RegularCooldown<>(
                 "Group Bonus",
                 null,
@@ -72,7 +73,7 @@ public class TDPiglin extends TowerDefenseMob implements BasicMob {
                 Collections.singletonList((cooldown, ticksLeft, cdTicksElapsed) -> {
                 })
         ).addModifier(Modifier.MODIFY_OUTGOING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult("Group Bonus", 1.3f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Group Bonus", 1.3f);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/mobs/TDStray.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/mobs/TDStray.java
@@ -6,6 +6,7 @@ import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.instances.type.CustomInstanceFlags;
 import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.tiers.BasicMob;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 
 public class TDStray extends TowerDefenseMob implements BasicMob {
@@ -38,11 +39,11 @@ public class TDStray extends TowerDefenseMob implements BasicMob {
     @Override
     public void onAttack(WarlordsEntity attacker, WarlordsEntity receiver, WarlordsDamageHealingEvent event) {
         event.getCustomFlags().add(new CustomInstanceFlags.Valued(
-                floatModifiable -> floatModifiable.addMultiplicativeModifierMult(name, .5f, 0),
+                floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, .5f, 0),
                 CustomInstanceFlags.Valued.Flag.TD_DEFENDER_ARMOR
         ));
         event.getCustomFlags().add(new CustomInstanceFlags.Valued(
-                floatModifiable -> floatModifiable.addMultiplicativeModifierMult(name, .5f, 0),
+                floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, .5f, 0),
                 CustomInstanceFlags.Valued.Flag.TD_DEFENDER_ARMOR
         ));
     }

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/mobs/TDZombifiedPiglin.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/mobs/TDZombifiedPiglin.java
@@ -8,6 +8,7 @@ import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.tiers.BasicMob;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 
 import java.util.Collections;
@@ -53,7 +54,7 @@ public class TDZombifiedPiglin extends TowerDefenseMob implements BasicMob {
         if (!inGroup) {
             return;
         }
-        getPhysicalResistance().addAdditiveModifier("Group Bonus", 20, 11);
+        getPhysicalResistance().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Group Bonus", 20, 11);
         warlordsNPC.getCooldownManager().addCooldown(new RegularCooldown<>(
                 "Group Bonus",
                 null,
@@ -67,7 +68,7 @@ public class TDZombifiedPiglin extends TowerDefenseMob implements BasicMob {
                 Collections.singletonList((cooldown, ticksLeft, cdTicksElapsed) -> {
                 })
         ).addModifier(Modifier.MODIFY_OUTGOING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult("Group Bonus", 1.3f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Group Bonus", 1.3f);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/mobs/TowerDefenseMob.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/mobs/TowerDefenseMob.java
@@ -151,9 +151,12 @@ public abstract class TowerDefenseMob extends AbstractMob {
                         }
                     }
                     if (flags.contains(InstanceFlags.TD_PHYSICAL)) {
-                        currentDamageValue.addMultiplicativeModifierMult("Physical Resistance", 1 - physicalResistance.getCalculatedValue());
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                "Physical Resistance",
+                                1 - physicalResistance.getCalculatedValue()
+                        );
                     } else if (flags.contains(InstanceFlags.TD_MAGIC)) {
-                        currentDamageValue.addMultiplicativeModifierMult("Magic Resistance", 1 - magicResistance.getCalculatedValue());
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Magic Resistance", 1 - magicResistance.getCalculatedValue());
                     }
                     physicalResistance.tick();
                     magicResistance.tick();

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/BerserkerTower.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/BerserkerTower.java
@@ -141,7 +141,7 @@ public class BerserkerTower extends AbstractTower implements Upgradeable.Path2 {
                                     }
                                 })
                         ).addModifier(Modifier.MODIFY_INCOMING_HEALING, (event, currentHealValue) -> {
-                                    currentHealValue.addMultiplicativeModifierMult("Bleed", 0.2f);
+                            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Bleed", 0.2f);
                                 }
                         ));
                     }

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/ConjurerTower.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/ConjurerTower.java
@@ -101,7 +101,9 @@ public class ConjurerTower extends AbstractTower implements Upgradeable.Path2 {
                             .value(damageValues.poisonDamage)
                             .flags(InstanceFlags.TD_MAGIC)
                             .customFlag(new CustomInstanceFlags.Valued(
-                                    floatModifiable -> floatModifiable.addMultiplicativeModifierMult(name + " Upgrade", .5f, 0),
+                                    floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                            name + " Upgrade", .5f, 0
+                                    ),
                                     CustomInstanceFlags.Valued.Flag.TD_MAGIC_RES_REDUCTION
                             ), pveMasterUpgrade)
                     );

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/CrusaderTower.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/CrusaderTower.java
@@ -113,8 +113,8 @@ public class CrusaderTower extends AbstractTower implements Upgradeable.Path2 {
                 abstractTower.getTowers(range)
                              .forEach(tower -> tower.getWarlordsTower()
                                                     .getAbilities()
-                                                    .forEach(ability -> ability.getCooldown().addMultiplicativeModifierAdd(
-                                                            abstractTower.getTowerRegistry().name,
+                                                    .forEach(ability -> ability.getCooldown().addModifier(
+                                                            FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, abstractTower.getTowerRegistry().name,
                                                             -buffValue.getCalculatedValue() / 100,
                                                             (int) (getCooldownValue() * 20) + 1
                                                     ))

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/DefenderTower.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/DefenderTower.java
@@ -190,7 +190,7 @@ public class DefenderTower extends AbstractTower implements Upgradeable.Path2 {
                 warlordsNPC.setDamageResistance(warlordsNPC.getSpec().getDamageResistance() + 10);
             }
             if (increasedHealth) {
-                warlordsNPC.getHealth().addMultiplicativeModifierAdd("Increased Health", .1f);
+                warlordsNPC.getHealth().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Increased Health", .1f);
             }
         }
 

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/EarthwardenTower.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/EarthwardenTower.java
@@ -52,13 +52,13 @@ public class EarthwardenTower extends AbstractTower implements Upgradeable.Path2
         upgrades.add(new TowerUpgrade("Upgrade 1", upgradeDamage1) {
             @Override
             public void onUpgrade() {
-//                flameDamage.addAdditiveModifier(name, upgradeDamage1.getValue());
+//                flameDamage.addModifier(name, upgradeDamage1.getValue());
             }
         });
         upgrades.add(new TowerUpgrade("Upgrade 2", upgradeDamage2) {
             @Override
             public void onUpgrade() {
-//                flameDamage.addAdditiveModifier(name, upgradeDamage2.getValue());
+//                flameDamage.addModifier(name, upgradeDamage2.getValue());
             }
         });
         upgrades.add(new TowerUpgrade("Attacks Slow Enemies", new TowerUpgradeInstance() {

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/LuminaryTower.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/LuminaryTower.java
@@ -56,16 +56,16 @@ public class LuminaryTower extends AbstractTower implements Upgradeable.Path2 {
         upgrades.add(new TowerUpgrade("Increased Buff Range", upgradeDamage4) {
             @Override
             public void onUpgrade() {
-                buffTowers.getBuffValue().addAdditiveModifier("Upgrade 3", upgradeBuff3.getValue());
+                buffTowers.getBuffValue().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade 3", upgradeBuff3.getValue());
             }
         });
         upgrades.add(new TowerUpgrade("Increase Damge and Healing", upgradeDamage4) {
             @Override
             protected void onUpgrade() {
-//                hexAttack.getMinDamageHeal().addAdditiveModifier("Upgrade 4", upgradeDamage4.getValue()); TODO
-//                hexAttack.getMaxDamageHeal().addAdditiveModifier("Upgrade 4", upgradeDamage4.getValue());
-//                mercifulHex.getMinDamageHeal().addAdditiveModifier("Upgrade 4", upgradeHealing4.getValue());
-//                mercifulHex.getMaxDamageHeal().addAdditiveModifier("Upgrade 4", upgradeHealing4.getValue());
+//                hexAttack.getMinDamageHeal().addModifier("Upgrade 4", upgradeDamage4.getValue()); TODO
+//                hexAttack.getMaxDamageHeal().addModifier("Upgrade 4", upgradeDamage4.getValue());
+//                mercifulHex.getMinDamageHeal().addModifier("Upgrade 4", upgradeHealing4.getValue());
+//                mercifulHex.getMaxDamageHeal().addModifier("Upgrade 4", upgradeHealing4.getValue());
             }
         });
     }
@@ -157,8 +157,8 @@ public class LuminaryTower extends AbstractTower implements Upgradeable.Path2 {
                                      .getAbilities()
                                      .forEach(ability -> {
                                          if (ability instanceof HitBox hitBox) {
-                                             hitBox.getHitBoxRadius().addMultiplicativeModifierAdd(
-                                                     abstractTower.getTowerRegistry().name,
+                                             hitBox.getHitBoxRadius().addModifier(
+                                                     FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, abstractTower.getTowerRegistry().name,
                                                      -buffValue.getCalculatedValue() / 100,
                                                      (int) (getCooldownValue() * 20) + 1
                                              );

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/PyromancerTower.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/PyromancerTower.java
@@ -54,19 +54,19 @@ public class PyromancerTower extends AbstractTower implements Upgradeable.Path2 
         upgrades.add(new TowerUpgrade("Upgrade 1", upgradeDamage1) {
             @Override
             public void onUpgrade() {
-//                flameDamage.addAdditiveModifier(name, upgradeDamage1.getValue());
+//                flameDamage.addModifier(name, upgradeDamage1.getValue());
             }
         });
         upgrades.add(new TowerUpgrade("Upgrade 2", upgradeDamage2) {
             @Override
             public void onUpgrade() {
-//                flameDamage.addAdditiveModifier(name, upgradeDamage2.getValue());
+//                flameDamage.addModifier(name, upgradeDamage2.getValue());
             }
         });
         upgrades.add(new TowerUpgrade("Future Damage + Minor AOE", upgradeDamage3) {
             @Override
             public void onUpgrade() {
-//                flameDamage.addAdditiveModifier(name, upgradeDamage3.getValue());
+//                flameDamage.addModifier(name, upgradeDamage3.getValue());
             }
         });
         upgrades.add(new TowerUpgrade("Burn", upgradeDamage3) {});
@@ -166,7 +166,7 @@ public class PyromancerTower extends AbstractTower implements Upgradeable.Path2 
                                     }
                                 })
                         ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                    currentDamageValue.addMultiplicativeModifierMult("Pyromancer Tower Burn", 1.2f);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Pyromancer Tower Burn", 1.2f);
                                 }
                         ));
                     }

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/RevenantTower.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/RevenantTower.java
@@ -73,7 +73,7 @@ public class RevenantTower extends AbstractTower implements Upgradeable.Path2, L
         }) {
             @Override
             protected void onUpgrade() {
-                spawnTroops.getHitBoxRadius().addAdditiveModifier("Upgrade 4", 5);
+                spawnTroops.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade 4", 5);
                 spawnTroops.setMaxSpawnCount(spawnTroops.getMaxSpawnCount() + 2);
                 spawnTroops.setPveMasterUpgrade2(true);
             }
@@ -219,7 +219,7 @@ public class RevenantTower extends AbstractTower implements Upgradeable.Path2, L
         public void onSpawn(PveOption option) {
             super.onSpawn(option);
             if (increasedEHP) {
-                warlordsNPC.getHealth().addMultiplicativeModifierAdd("Increased EHP", .1f);
+                warlordsNPC.getHealth().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Increased EHP", .1f);
             }
         }
 

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/SentinelTower.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/SentinelTower.java
@@ -249,8 +249,8 @@ public class SentinelTower extends AbstractTower implements Upgradeable.Path2 {
                                      .getAbilities()
                                      .forEach(ability -> {
                                          if (ability instanceof HitBox hitBox) {
-                                             hitBox.getHitBoxRadius().addMultiplicativeModifierAdd(
-                                                     abstractTower.getTowerRegistry().name,
+                                             hitBox.getHitBoxRadius().addModifier(
+                                                     FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, abstractTower.getTowerRegistry().name,
                                                      -buffValue.getCalculatedValue() / 100,
                                                      (int) (getCooldownValue() * 20) + 1
                                              );

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/ThunderlordTower.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/ThunderlordTower.java
@@ -37,13 +37,13 @@ public class ThunderlordTower extends AbstractTower implements Upgradeable.Path2
         upgrades.add(new TowerUpgrade("Upgrade 1", upgradeDamage1) {
             @Override
             public void onUpgrade() {
-//                flameDamage.addAdditiveModifier(name, upgradeDamage1.getValue());
+//                flameDamage.addModifier(name, upgradeDamage1.getValue());
             }
         });
         upgrades.add(new TowerUpgrade("Upgrade 2", upgradeDamage2) {
             @Override
             public void onUpgrade() {
-//                flameDamage.addAdditiveModifier(name, upgradeDamage2.getValue());
+//                flameDamage.addModifier(name, upgradeDamage2.getValue());
             }
         });
         upgrades.add(new TowerUpgrade("Stun", upgradeDamage3) {

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/TowerDefenseTowerMob.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/TowerDefenseTowerMob.java
@@ -129,7 +129,7 @@ public abstract class TowerDefenseTowerMob extends AbstractMob implements Mob {
                             floatModifiableConsumer.accept(armor);
                         }
                     }
-                    currentDamageValue.addMultiplicativeModifierMult("Armor", (1 - armor.getCalculatedValue()));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Armor", (1 - armor.getCalculatedValue()));
                     armor.tick();
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/VindicatorTower.java
+++ b/src/main/java/com/ebicep/warlords/game/option/towerdefense/towers/VindicatorTower.java
@@ -67,8 +67,8 @@ public class VindicatorTower extends AbstractTower implements Upgradeable.Path2 
             @Override
             protected void onUpgrade() {
                 strikeAttack.setMobsHit(2);
-//                strikeAttack.getMinDamageHeal().addMultiplicativeModifierAdd(name, -.3f); TODO
-//                strikeAttack.getMaxDamageHeal().addMultiplicativeModifierAdd(name, -.3f);
+//                strikeAttack.getMinDamageHeal().addModifier(name, -.3f); TODO
+//                strikeAttack.getMaxDamageHeal().addModifier(name, -.3f);
             }
         });
     }
@@ -114,7 +114,7 @@ public class VindicatorTower extends AbstractTower implements Upgradeable.Path2 
                             .flags(InstanceFlags.TD_PHYSICAL)
                     );
                     if (warlordsNPC.getMob() instanceof TowerDefenseMob towerDefenseMob) {
-                        towerDefenseMob.getMagicResistance().addAdditiveModifier(name, -10);
+                        towerDefenseMob.getMagicResistance().addModifier(FloatModifiable.ModifierType.ADDITIVE, name, -10);
                     }
                     if (pveMasterUpgrade) {
                         SoulShackle.shacklePlayer(wp, warlordsNPC, 10);

--- a/src/main/java/com/ebicep/warlords/game/option/whackamole/WhackAMoleOption.java
+++ b/src/main/java/com/ebicep/warlords/game/option/whackamole/WhackAMoleOption.java
@@ -15,6 +15,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.pve.mobs.AbstractMob;
 import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.OfflinePlayer;
@@ -134,10 +135,10 @@ public class WhackAMoleOption implements PveOption, Listener {
             return;
         }
         event.applyToMinMax(floatModifiable ->
-                floatModifiable.addOverridingModifier("WackAMole", 100)
+                floatModifiable.addModifier(FloatModifiable.ModifierType.OVERRIDING, "WackAMole", 100)
         );
-        event.getCritChance().addOverridingModifier("WackAMole", 0);
-        event.getCritMultiplier().addOverridingModifier("WackAMole", 100);
+        event.getCritChance().addModifier(FloatModifiable.ModifierType.OVERRIDING, "WackAMole", 0);
+        event.getCritMultiplier().addModifier(FloatModifiable.ModifierType.OVERRIDING, "WackAMole", 100);
     }
 
     public static class WhackAMoleMobData extends MobData {

--- a/src/main/java/com/ebicep/warlords/player/general/SkillBoosts.java
+++ b/src/main/java/com/ebicep/warlords/player/general/SkillBoosts.java
@@ -2,6 +2,7 @@ package com.ebicep.warlords.player.general;
 
 import com.ebicep.warlords.abilities.*;
 import com.ebicep.warlords.abilities.internal.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -25,7 +26,7 @@ public enum SkillBoosts {
                     fireball.getDamageValues()
                             .getFireballDamage()
                             .forEachValue(floatModifiable -> {
-                                floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .1f);
+                                floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .1f);
                             });
                     fireball.setDirectHitMultiplier(fireball.getDirectHitMultiplier() + 25);
                 }
@@ -45,9 +46,9 @@ public enum SkillBoosts {
                     flameBurst.getDamageValues()
                               .getFlameBurstDamage()
                               .forEachValue(floatModifiable -> {
-                                  floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .25f);
+                                  floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .25f);
                               });
-                    abstractAbility.getEnergyCost().addAdditiveModifier("Skill Boost", -40);
+                    abstractAbility.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Skill Boost", -40);
                 }
             }
     ),
@@ -63,7 +64,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof TimeWarpPyromancer timeWarp) {
                     timeWarp.setWarpHealPercentage(timeWarp.getWarpHealPercentage() + 15);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .45f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .45f);
                 }
             }
     ),
@@ -76,8 +77,8 @@ public enum SkillBoosts {
             AbstractArcaneShield.class,
             abstractAbility -> {
                 if (abstractAbility instanceof AbstractArcaneShield) {
-                    abstractAbility.getEnergyCost().addMultiplicativeModifierMult("Skill Boost", 0);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .45f);
+                    abstractAbility.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", 0);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .45f);
                 }
             }
     ),
@@ -119,7 +120,7 @@ public enum SkillBoosts {
             FreezingBreath.class,
             abstractAbility -> {
                 if (abstractAbility instanceof FreezingBreath) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .7f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .7f);
                 }
             }
     ),
@@ -132,7 +133,7 @@ public enum SkillBoosts {
             TimeWarpCryomancer.class,
             abstractAbility -> {
                 if (abstractAbility instanceof TimeWarpCryomancer) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .6f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .6f);
                 }
             }
     ),
@@ -145,7 +146,7 @@ public enum SkillBoosts {
             AbstractArcaneShield.class,
             abstractAbility -> {
                 if (abstractAbility instanceof AbstractArcaneShield) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .7f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .7f);
                 }
             }
     ),
@@ -179,9 +180,9 @@ public enum SkillBoosts {
                     waterBolt.getHealValues()
                              .getBoltHealing()
                              .forEachValue(floatModifiable -> {
-                                 floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .1f);
+                                 floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .1f);
                              });
-                    waterBolt.getDirectHitMultiplier().addAdditiveModifier("Skill Boost", 25);
+                    waterBolt.getDirectHitMultiplier().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Skill Boost", 25);
                 }
             }
     ),
@@ -196,8 +197,8 @@ public enum SkillBoosts {
             WaterBreath.class,
             abstractAbility -> {
                 if (abstractAbility instanceof WaterBreath) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .85f);
-                    abstractAbility.getEnergyCost().addAdditiveModifier("Skill Boost", -30);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .85f);
+                    abstractAbility.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Skill Boost", -30);
                 }
             }
     ),
@@ -213,7 +214,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof TimeWarpAquamancer timeWarpAquamancer) {
                     timeWarpAquamancer.setTickDuration(timeWarpAquamancer.getTickDuration() + 60);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .7f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .7f);
                 }
             }
     ),
@@ -226,8 +227,8 @@ public enum SkillBoosts {
             AbstractArcaneShield.class,
             abstractAbility -> {
                 if (abstractAbility instanceof AbstractArcaneShield) {
-                    abstractAbility.getEnergyCost().addMultiplicativeModifierMult("Skill Boost", 0);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .5f);
+                    abstractAbility.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", 0);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .5f);
                 }
             }
     ),
@@ -243,7 +244,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof HealingRain healingRain) {
                     healingRain.setTickDuration(healingRain.getTickDuration() + 40);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .8f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .8f);
                 }
             }
     ),
@@ -261,9 +262,9 @@ public enum SkillBoosts {
                     woundingStrikeBerserker.getDamageValues()
                                            .getStrikeDamage()
                                            .forEachValue(floatModifiable -> {
-                                               floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .1f);
+                                               floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .1f);
                                            });
-                    abstractAbility.getEnergyCost().addAdditiveModifier("Skill Boost", -10);
+                    abstractAbility.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Skill Boost", -10);
                 }
             }
     ),
@@ -281,9 +282,9 @@ public enum SkillBoosts {
                     seismicWaveBerserker.getDamageValues()
                                         .getWaveDamage()
                                         .forEachValue(floatModifiable -> {
-                                            floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .15f);
+                                            floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .15f);
                                         });
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .75f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .75f);
                 }
             }
     ),
@@ -299,9 +300,9 @@ public enum SkillBoosts {
                     groundSlamBerserker.getDamageValues()
                                        .getSlamDamage()
                                        .forEachValue(floatModifiable -> {
-                                           floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .4f);
+                                           floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .4f);
                                        });
-                    abstractAbility.getEnergyCost().addMultiplicativeModifierMult("Skill Boost", 0);
+                    abstractAbility.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", 0);
                 }
             }
     ),
@@ -317,7 +318,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof BloodLust bloodLust) {
                     bloodLust.setDamageConvertPercent(bloodLust.getDamageConvertPercent() + 20);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .65f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .65f);
                 }
             }
     ),
@@ -351,9 +352,9 @@ public enum SkillBoosts {
                     woundingStrikeDefender.getDamageValues()
                                           .getStrikeDamage()
                                           .forEachValue(floatModifiable -> {
-                                              floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .15f);
+                                              floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .15f);
                                           });
-                    woundingStrikeDefender.getWounding().addAdditiveModifier("Skill Boost", 10);
+                    woundingStrikeDefender.getWounding().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Skill Boost", 10);
                 }
             }
     ),
@@ -369,7 +370,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof AbstractSeismicWave seismicWave) {
                     seismicWave.setVelocity(1.5f);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .85f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .85f);
                 }
             }
     ),
@@ -385,7 +386,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof AbstractGroundSlam groundSlam) {
                     groundSlam.setVelocity(1.35f);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .75f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .75f);
                 }
             }
     ),
@@ -419,7 +420,7 @@ public enum SkillBoosts {
                 if (abstractAbility instanceof LastStand lastStand) {
                     lastStand.setSelfDamageReductionPercent((int) (lastStand.getSelfDamageReduction() + 5));
                     lastStand.setTeammateDamageReductionPercent((int) (lastStand.getTeammateDamageReduction() + 5));
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .9f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .9f);
                 }
             }
     ),
@@ -438,7 +439,7 @@ public enum SkillBoosts {
                 if (abstractAbility instanceof CripplingStrike cripplingStrike) {
                     cripplingStrike.setCripple(cripplingStrike.getCripple() + 10);
                     cripplingStrike.setCripplePerStrike(cripplingStrike.getCripplePerStrike() + 5);
-                    abstractAbility.getEnergyCost().addAdditiveModifier("Skill Boost", -10);
+                    abstractAbility.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Skill Boost", -10);
                 }
             }
     ),
@@ -454,7 +455,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof RecklessCharge recklessCharge) {
                     recklessCharge.setStunTimeInTicks(recklessCharge.getStunTimeInTicks() + 10);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .7f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .7f);
                 }
             }
     ),
@@ -467,7 +468,7 @@ public enum SkillBoosts {
             GroundSlamRevenant.class,
             abstractAbility -> {
                 if (abstractAbility instanceof GroundSlamRevenant) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .7f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .7f);
                 }
             }
     ),
@@ -483,7 +484,7 @@ public enum SkillBoosts {
                     orbsOfLife.getHealValues()
                               .getOrbHealing()
                               .forEachValue(floatModifiable -> {
-                                  floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .2f);
+                                  floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .2f);
                               });
                 }
             }
@@ -518,7 +519,7 @@ public enum SkillBoosts {
                     avengersStrike.getDamageValues()
                                   .getStrikeDamage()
                                   .forEachValue(floatModifiable -> {
-                                      floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .1f);
+                                      floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .1f);
                                   });
                     avengersStrike.setEnergySteal(avengersStrike.getEnergySteal() + 5);
                 }
@@ -533,11 +534,11 @@ public enum SkillBoosts {
             ConsecrateAvenger.class,
             abstractAbility -> {
                 if (abstractAbility instanceof ConsecrateAvenger consecrateAvenger) {
-                    abstractAbility.getEnergyCost().addMultiplicativeModifierMult("Skill Boost", 0);
+                    abstractAbility.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", 0);
                     consecrateAvenger.getDamageValues()
                                      .getConsecrateDamage()
                                      .forEachValue(floatModifiable -> {
-                                         floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .4f);
+                                         floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .4f);
                                      });
                 }
             }
@@ -553,7 +554,7 @@ public enum SkillBoosts {
             LightInfusionAvenger.class,
             abstractAbility -> {
                 if (abstractAbility instanceof LightInfusionAvenger lightInfusion) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .65f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .65f);
                     lightInfusion.setTickDuration(lightInfusion.getTickDuration() + 80);
                 }
             }
@@ -569,7 +570,7 @@ public enum SkillBoosts {
             HolyRadianceAvenger.class,
             abstractAbility -> {
                 if (abstractAbility instanceof HolyRadianceAvenger holyRadiance) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .7f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .7f);
                     holyRadiance.setEnergyDrainPerSecond(holyRadiance.getEnergyDrainPerSecond() * 1.5f);
                 }
             }
@@ -604,7 +605,7 @@ public enum SkillBoosts {
                     crusadersStrike.getDamageValues()
                             .getStrikeDamage()
                             .forEachValue(floatModifiable -> {
-                                floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .1f);
+                                floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .1f);
                             });
                     crusadersStrike.setEnergyGiven(crusadersStrike.getEnergyGiven() + 3);
                 }
@@ -619,11 +620,11 @@ public enum SkillBoosts {
             ConsecrateCrusader.class,
             abstractAbility -> {
                 if (abstractAbility instanceof ConsecrateCrusader consecrateCrusader) {
-                    abstractAbility.getEnergyCost().addMultiplicativeModifierMult("Skill Boost", 0);
+                    abstractAbility.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", 0);
                     consecrateCrusader.getDamageValues()
                                       .getConsecrateDamage()
                                       .forEachValue(floatModifiable -> {
-                                          floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .35f);
+                                          floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .35f);
                                       });
                 }
             }
@@ -639,7 +640,7 @@ public enum SkillBoosts {
             LightInfusionCrusader.class,
             abstractAbility -> {
                 if (abstractAbility instanceof LightInfusionCrusader lightInfusion) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .65f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .65f);
                     lightInfusion.setTickDuration(lightInfusion.getTickDuration() + 80);
                 }
             }
@@ -657,7 +658,7 @@ public enum SkillBoosts {
             HolyRadianceCrusader.class,
             abstractAbility -> {
                 if (abstractAbility instanceof HolyRadianceCrusader holyRadiance) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .75f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .75f);
                     holyRadiance.setMarkDuration(holyRadiance.getMarkDuration() + 4);
                     holyRadiance.setMarkSpeed(holyRadiance.getMarkSpeed() + 15);
                 }
@@ -674,7 +675,7 @@ public enum SkillBoosts {
             InspiringPresence.class,
             abstractAbility -> {
                 if (abstractAbility instanceof InspiringPresence inspiringPresence) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .75f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .75f);
                     inspiringPresence.setSpeedBuff(inspiringPresence.getSpeedBuff() + 10);
                 }
             }
@@ -703,8 +704,8 @@ public enum SkillBoosts {
             ConsecrateProtector.class,
             abstractAbility -> {
                 if (abstractAbility instanceof AbstractConsecrate consecrate) {
-                    consecrate.getHitBoxRadius().addAdditiveModifier("Skill Boost", 2);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .6f);
+                    consecrate.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Skill Boost", 2);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .6f);
                 }
             }
     ),
@@ -719,7 +720,7 @@ public enum SkillBoosts {
             LightInfusionProtector.class,
             abstractAbility -> {
                 if (abstractAbility instanceof LightInfusionProtector lightInfusion) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .65f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .65f);
                     lightInfusion.setTickDuration(lightInfusion.getTickDuration() + 80);
                 }
             }
@@ -736,7 +737,7 @@ public enum SkillBoosts {
                     holyRadianceProtector.getHealValues()
                                          .getRadianceHealing()
                                          .forEachValue(floatModifiable -> {
-                                             floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .2f);
+                                             floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .2f);
                                          });
                 }
             }
@@ -755,9 +756,9 @@ public enum SkillBoosts {
                     hammerOfLight.getHealValues()
                                  .getHammerHealing()
                                  .forEachValue(floatModifiable -> {
-                                     floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .25f);
+                                     floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .25f);
                                  });
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .8f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .8f);
                 }
             }
     ),
@@ -773,7 +774,7 @@ public enum SkillBoosts {
                     lightningBolt.getDamageValues()
                                  .getBoltDamage()
                                  .forEachValue(floatModifiable -> {
-                                     floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .2f);
+                                     floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .2f);
                                  });
                 }
             }
@@ -792,9 +793,9 @@ public enum SkillBoosts {
                     chainLightning.getDamageValues()
                                   .getChainDamage()
                                   .forEachValue(floatModifiable -> {
-                                      floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .25f);
+                                      floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .25f);
                                   });
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .85f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .85f);
                 }
             }
     ),
@@ -823,7 +824,7 @@ public enum SkillBoosts {
             LightningRod.class,
             abstractAbility -> {
                 if (abstractAbility instanceof LightningRod) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .6f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .6f);
                 }
             }
     ),
@@ -836,7 +837,7 @@ public enum SkillBoosts {
             CapacitorTotem.class,
             abstractAbility -> {
                 if (abstractAbility instanceof CapacitorTotem) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .6f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .6f);
                 }
             }
     ),
@@ -852,7 +853,7 @@ public enum SkillBoosts {
                     fallenSouls.getDamageValues()
                                .getFallenSoulDamage()
                                .forEachValue(floatModifiable -> {
-                                   floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .25f);
+                                   floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .25f);
                                });
                 }
             }
@@ -871,7 +872,7 @@ public enum SkillBoosts {
                     spiritLink.getDamageValues()
                               .getLinkDamage()
                               .forEachValue(floatModifiable -> {
-                                  floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .25f);
+                                  floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .25f);
                               });
                     spiritLink.setSpeedDuration(spiritLink.getSpeedDuration() + 0.5f);
                 }
@@ -889,12 +890,12 @@ public enum SkillBoosts {
                     soulbinding.getHealValues()
                                .getAllyHealing()
                                .forEachValue(floatModifiable -> {
-                                   floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .2f);
+                                   floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .2f);
                                });
                     soulbinding.getHealValues()
                                .getSelfHealing()
                                .forEachValue(floatModifiable -> {
-                                   floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .2f);
+                                   floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .2f);
                                });
                 }
             }
@@ -911,7 +912,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof Repentance repentance) {
                     repentance.setDamageConvertPercent(repentance.getDamageConvertPercent() + 5);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .9f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .9f);
                 }
             }
     ),
@@ -946,7 +947,7 @@ public enum SkillBoosts {
                     earthenSpike.getDamageValues()
                                 .getSpikeDamage()
                                 .forEachValue(floatModifiable -> {
-                                    floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .15f);
+                                    floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .15f);
                                 });
                     earthenSpike.setSpeed(earthenSpike.getSpeed() * 1.2f);
                 }
@@ -964,7 +965,7 @@ public enum SkillBoosts {
                     boulder.getDamageValues()
                            .getBoulderDamage()
                            .forEachValue(floatModifiable -> {
-                               floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .2f);
+                               floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .2f);
                            });
                 }
             }
@@ -994,7 +995,7 @@ public enum SkillBoosts {
                     chainHeal.getHealValues()
                              .getChainHealing()
                              .forEachValue(floatModifiable -> {
-                                 floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .3f);
+                                 floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .3f);
                              });
                 }
             }
@@ -1013,9 +1014,9 @@ public enum SkillBoosts {
                     healingTotem.getHealValues()
                                 .getTotemHealing()
                                 .forEachValue(floatModifiable -> {
-                                    floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .25f);
+                                    floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .25f);
                                 });
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .75f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .75f);
                 }
             }
     ),
@@ -1031,7 +1032,7 @@ public enum SkillBoosts {
                     judgementStrike.getDamageValues()
                                    .getStrikeDamage()
                                    .forEachValue(floatModifiable -> {
-                                       floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .2f);
+                                       floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .2f);
                                    });
                 }
             }
@@ -1048,7 +1049,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof IncendiaryCurse incendiaryCurse) {
                     incendiaryCurse.setBlindDurationInTicks(incendiaryCurse.getBlindDurationInTicks() + 10);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .6f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .6f);
                 }
             }
     ),
@@ -1062,7 +1063,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof ShadowStep shadowStep) {
                     shadowStep.setFallDamageNegation(1000);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .5f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .5f);
                 }
             }
     ),
@@ -1077,8 +1078,8 @@ public enum SkillBoosts {
             SoulSwitch.class,
             abstractAbility -> {
                 if (abstractAbility instanceof SoulSwitch soulSwitch) {
-                    soulSwitch.getHitBoxRadius().addAdditiveModifier("Skill Boost", 6);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .4f);
+                    soulSwitch.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Skill Boost", 6);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .4f);
                 }
             }
     ),
@@ -1094,7 +1095,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof OrderOfEviscerate orderOfEviscerate) {
                     orderOfEviscerate.setTickDuration(orderOfEviscerate.getTickDuration() + 120);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .65f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .65f);
                 }
             }
     ),
@@ -1110,7 +1111,7 @@ public enum SkillBoosts {
                     righteousStrike.getDamageValues()
                                    .getStrikeDamage()
                                    .forEachValue(floatModifiable -> {
-                                       floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .2f);
+                                       floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .2f);
                                    });
                 }
             }
@@ -1124,7 +1125,7 @@ public enum SkillBoosts {
             SoulShackle.class,
             abstractAbility -> {
                 if (abstractAbility instanceof SoulShackle) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .8f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .8f);
                 }
             }
     ),
@@ -1137,7 +1138,7 @@ public enum SkillBoosts {
             HeartToHeart.class,
             abstractAbility -> {
                 if (abstractAbility instanceof HeartToHeart) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .8f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .8f);
                 }
             }
     ),
@@ -1153,7 +1154,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof PrismGuard prismGuard) {
                     prismGuard.setProjectileDamageReduction(prismGuard.getProjectileDamageReduction() + 15);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .85f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .85f);
                 }
             }
     ),
@@ -1169,7 +1170,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof Vindicate vindicate) {
                     vindicate.setVindicateDamageReduction(vindicate.getVindicateDamageReduction() + 10);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .75f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .75f);
                 }
             }
     ),
@@ -1188,7 +1189,7 @@ public enum SkillBoosts {
                     impalingStrike.getDamageValues()
                                   .getStrikeDamage()
                                   .forEachValue(floatModifiable -> {
-                                      floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .125f);
+                                      floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .125f);
                                   });
                 }
             }
@@ -1205,7 +1206,7 @@ public enum SkillBoosts {
                     soothingElixir.getHealValues()
                                   .getElixirHealing()
                                   .forEachValue(floatModifiable -> {
-                                      floatModifiable.addMultiplicativeModifierAdd("Skill Boost", .25f);
+                                      floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", .25f);
                                   });
                 }
             }
@@ -1219,7 +1220,7 @@ public enum SkillBoosts {
             VitalityConcoction.class,
             abstractAbility -> {
                 if (abstractAbility instanceof VitalityConcoction vitalityConcoction) {
-                    abstractAbility.getEnergyCost().addMultiplicativeModifierMult("Skill Boost", 0);
+                    abstractAbility.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", 0);
                     vitalityConcoction.setTickDuration(vitalityConcoction.getTickDuration() + 20);
                 }
             }
@@ -1235,7 +1236,7 @@ public enum SkillBoosts {
             RemedicChains.class,
             abstractAbility -> {
                 if (abstractAbility instanceof RemedicChains remedicChains) {
-                    remedicChains.getDamageValues().getBonusDamage().value().addAdditiveModifier("Skill Boost", 30);
+                    remedicChains.getDamageValues().getBonusDamage().value().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Skill Boost", 30);
                     remedicChains.setLinkBreakRadius(remedicChains.getLinkBreakRadius() + 10);
                 }
             }
@@ -1252,7 +1253,7 @@ public enum SkillBoosts {
             abstractAbility -> {
                 if (abstractAbility instanceof DrainingMiasma drainingMiasma) {
                     drainingMiasma.setLeechTickDuration(drainingMiasma.getLeechTickDuration() + 5);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .8f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .8f);
                 }
             }
     ),
@@ -1281,7 +1282,7 @@ public enum SkillBoosts {
             SoulfireBeam.class,
             abstractAbility -> {
                 if (abstractAbility instanceof SoulfireBeam) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .8f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .8f);
                 }
             }
     ),
@@ -1294,7 +1295,7 @@ public enum SkillBoosts {
             EnergySeerConjurer.class,
             abstractAbility -> {
                 if (abstractAbility instanceof EnergySeerConjurer) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .55f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .55f);
                 }
             }
     ),
@@ -1313,8 +1314,8 @@ public enum SkillBoosts {
             ContagiousFacade.class,
             abstractAbility -> {
                 if (abstractAbility instanceof ContagiousFacade contagiousFacade) {
-                    contagiousFacade.getDamageAbsorption().addAdditiveModifier("Skill Boost", 20);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .7f);
+                    contagiousFacade.getDamageAbsorption().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Skill Boost", 20);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .7f);
                     contagiousFacade.setStacksGranted(contagiousFacade.getStacksGranted() + 1);
                     contagiousFacade.setInfectedPlayers(contagiousFacade.getInfectedPlayers() + 1);
                 }
@@ -1331,7 +1332,7 @@ public enum SkillBoosts {
             AstralPlague.class,
             abstractAbility -> {
                 if (abstractAbility instanceof AstralPlague astralPlague) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .8f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .8f);
                     astralPlague.setTickDuration(astralPlague.getTickDuration() + 240);
                 }
             }
@@ -1347,7 +1348,7 @@ public enum SkillBoosts {
             FortifyingHex.class,
             abstractAbility -> {
                 if (abstractAbility instanceof FortifyingHex fortifyingHex) {
-                    fortifyingHex.getDamageReduction().addAdditiveModifier("Skill Boost", 2);
+                    fortifyingHex.getDamageReduction().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Skill Boost", 2);
                     fortifyingHex.setTickDuration(fortifyingHex.getTickDuration() + 40);
                 }
             }
@@ -1361,7 +1362,7 @@ public enum SkillBoosts {
             GuardianBeam.class,
             abstractAbility -> {
                 if (abstractAbility instanceof GuardianBeam) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .8f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .8f);
                 }
             }
     ),
@@ -1403,7 +1404,7 @@ public enum SkillBoosts {
             Sanctuary.class,
             abstractAbility -> {
                 if (abstractAbility instanceof Sanctuary) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .75f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .75f);
                 }
             }
     ),
@@ -1421,7 +1422,7 @@ public enum SkillBoosts {
                     mercifulHex.getHealValues()
                                .getHexDOTHealing()
                                .forEachValue(floatModifiable -> {
-                                   floatModifiable.addMultiplicativeModifierAdd("Skill Boost", 1.0f);
+                                   floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Skill Boost", 1.0f);
                                });
                     mercifulHex.setTickDuration(mercifulHex.getTickDuration() + 20);
                 }
@@ -1436,7 +1437,7 @@ public enum SkillBoosts {
             RayOfLight.class,
             abstractAbility -> {
                 if (abstractAbility instanceof RayOfLight) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .8f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .8f);
                 }
             }
     ),
@@ -1464,8 +1465,8 @@ public enum SkillBoosts {
             SanctifiedBeacon.class,
             abstractAbility -> {
                 if (abstractAbility instanceof SanctifiedBeacon sanctifiedBeacon) {
-                    abstractAbility.getEnergyCost().addMultiplicativeModifierMult("Skill Boost", 0);
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .5f);
+                    abstractAbility.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", 0);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .5f);
                     sanctifiedBeacon.setCritMultiplierReducedBy(sanctifiedBeacon.getCritMultiplierReducedBy() + 15);
                 }
             }
@@ -1479,7 +1480,7 @@ public enum SkillBoosts {
             DivineBlessing.class,
             abstractAbility -> {
                 if (abstractAbility instanceof DivineBlessing) {
-                    abstractAbility.getCooldown().addMultiplicativeModifierMult("Skill Boost", .75f);
+                    abstractAbility.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Skill Boost", .75f);
                 }
             }
     ),

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AbyssalGrasp.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AbyssalGrasp.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.util.bukkit.LocationBuilder;
 import com.ebicep.warlords.util.java.MathUtils;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 
@@ -62,8 +63,10 @@ public class AbyssalGrasp implements SpecBoostManager.SpecBoost<AbyssalGrasp> {
             warlordsPlayer.getAbilitiesMatching(SoulShackle.class).forEach(soulShackle -> {
                 soulShackle.getDamageValues()
                            .getShackleDamage()
-                           .forEachValue(floatModifiable -> floatModifiable.addMultiplicativeModifierAdd("Spec Boost", soulShackleDamageIncreasePercent / 100));
-                soulShackle.getCooldown().addAdditiveModifier("Spec Boost", soulShackleCooldownIncreaseTicks / 20f);
+                           .forEachValue(floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                                   "Spec Boost", soulShackleDamageIncreasePercent / 100
+                           ));
+                soulShackle.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", soulShackleCooldownIncreaseTicks / 20f);
                 this.soulShackleRange = soulShackle.getShackleRange() - soulShackleRangeDecrease;
                 soulShackle.setShackleRange(soulShackleRange);
             });

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AcceleratedSpike.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AcceleratedSpike.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.abilities.EarthenSpike;
 import com.ebicep.warlords.abilities.internal.AbstractAbility;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -54,14 +55,14 @@ public class AcceleratedSpike implements SpecBoostManager.SpecBoost<AcceleratedS
 
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
-            warlordsPlayer.getEnergy().addAdditiveModifier("Spec Boost", maxEnergyIncrease);
+            warlordsPlayer.getEnergy().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", maxEnergyIncrease);
             warlordsPlayer.getAbilitiesMatching(EarthenSpike.class).forEach(earthenSpike -> {
                 earthenSpike.setVerticalVelocity(0);
                 earthenSpike.setSpeed(earthenSpike.getSpeed() * AbstractAbility.convertToMultiplicationDecimal(travelSpeedIncreasePercent));
-                earthenSpike.getHitBoxRadius().addAdditiveModifier("Spec Boost", castRangeIncrease);
+                earthenSpike.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", castRangeIncrease);
                 earthenSpike.setSpikeHitbox(hitRadius);
                 earthenSpike.getDamageValues().getSpikeDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", damageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", damageIncreasePercent / 100)
                 );
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AirStrike.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AirStrike.java
@@ -123,8 +123,10 @@ public class AirStrike implements SpecBoostManager.SpecBoost<AirStrike> {
                         }
                         List<FloatModifiable.FloatModifier> modifiers = new ArrayList<>();
                         warlordsEntity.getAbilitiesMatching(SoulfireBeam.class).forEach(soulfireBeam -> {
-                            modifiers.add(soulfireBeam.getCooldown().addOverridingModifier(getStringName(), 0, airStrikeDurationTicks));
-                            modifiers.add(soulfireBeam.getMaxDistance().addAdditiveModifier(getStringName(), -soulfireBeamRangeDecrease, airStrikeDurationTicks));
+                            modifiers.add(soulfireBeam.getCooldown().addModifier(FloatModifiable.ModifierType.OVERRIDING, getStringName(), 0, airStrikeDurationTicks));
+                            modifiers.add(soulfireBeam.getMaxDistance().addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                                    getStringName(), -soulfireBeamRangeDecrease, airStrikeDurationTicks
+                            ));
                             soulfireBeam.setCurrentCooldown(0);
                         });
                         warlordsEntity.getCooldownManager().addCooldown(new RegularCooldown<>(
@@ -168,7 +170,7 @@ public class AirStrike implements SpecBoostManager.SpecBoost<AirStrike> {
                                             return;
                                         }
                                         if (event.getAbility() instanceof SoulfireBeam soulfireBeam) {
-                                            soulfireBeam.getHitBoxRadius().addAdditiveModifier("Spec Boost", soulfireBeamHitboxIncrease);
+                                            soulfireBeam.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", soulfireBeamHitboxIncrease);
                                         } else {
                                             event.setCancelled(true);
                                         }
@@ -212,7 +214,9 @@ public class AirStrike implements SpecBoostManager.SpecBoost<AirStrike> {
                             }
                         }.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (e, currentDamageValue) -> {
                                     if (event.getAbility() instanceof SoulfireBeam) {
-                                        currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToDivisionDecimal(soulfireBeamDamageReductionPercent));
+                                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                                getStringName(), AbstractAbility.convertToDivisionDecimal(soulfireBeamDamageReductionPercent)
+                                        );
                                     }
                                 }
                         ));

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AlchemistsFury.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AlchemistsFury.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.abilities.SoothingElixir;
 import com.ebicep.warlords.abilities.VolatileBrew;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -49,14 +50,14 @@ public class AlchemistsFury implements SpecBoostManager.SpecBoost<AlchemistsFury
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(SoothingElixir.class).forEach(soothingElixir -> {
-                soothingElixir.getCooldown().addAdditiveModifier("Spec Boost", -soothingElixirCooldownReductionSeconds);
+                soothingElixir.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -soothingElixirCooldownReductionSeconds);
                 soothingElixir.setSpeed(soothingElixir.getSpeed() * soothingElixirProjectileSpeedMultiplier);
                 soothingElixir.setGravity(soothingElixir.getGravity() * soothingElixirProjectileSpeedMultiplier);
                 soothingElixir.getDamageValues().getElixirDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", soothingElixirDamageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", soothingElixirDamageIncreasePercent / 100)
                 );
                 soothingElixir.getHealValues().getElixirDOTHealing().forEachValue(floatModifiable ->
-                        floatModifiable.addOverridingModifier("Spec Boost", 0)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.OVERRIDING, "Spec Boost", 0)
                 );
             });
             warlordsPlayer.getAbilitiesMatching(VolatileBrew.class).forEach(volatileBrew -> {

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ArcaneRecluse.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ArcaneRecluse.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.internal.AbstractArcaneShield;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -43,7 +44,7 @@ public class ArcaneRecluse implements SpecBoostManager.SpecBoost<ArcaneRecluse> 
 
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
-            warlordsPlayer.getHealth().addAdditiveModifier("Spec Boost (Base)", healthIncrease);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost (Base)", healthIncrease);
             warlordsPlayer.getAbilitiesMatching(AbstractArcaneShield.class).forEach(arcaneShield -> {
                 arcaneShield.setTickDuration(arcaneShield.getTickDuration() + shieldTickDurationIncrease);
                 arcaneShield.setShieldPercentage(arcaneShield.getShieldPercentage() + absorptionIncreasePercent);

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ArcaneReflection.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ArcaneReflection.java
@@ -15,6 +15,7 @@ import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -69,7 +70,9 @@ public class ArcaneReflection implements SpecBoostManager.SpecBoost<ArcaneReflec
             warlordsPlayer.getAbilitiesMatching(WaterBolt.class).forEach(waterBolt ->
                     waterBolt.getDamageValues()
                              .getBoltDamage()
-                             .forEachValue(floatModifiable -> floatModifiable.addMultiplicativeModifierAdd("Arcane Reflection", waterBoltDamageIncreasePercent / 100))
+                             .forEachValue(floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                                     "Arcane Reflection", waterBoltDamageIncreasePercent / 100
+                             ))
             );
             warlordsPlayer.getCooldownManager().addCooldown(new PermanentCooldown<>(
                     getStringName(),
@@ -83,7 +86,10 @@ public class ArcaneReflection implements SpecBoostManager.SpecBoost<ArcaneReflec
                     false
             ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                         if (event.getCause().isEmpty()) {
-                            currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToMultiplicationDecimal(meleeDamageIncreasePercent));
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                    getStringName(),
+                                    AbstractAbility.convertToMultiplicationDecimal(meleeDamageIncreasePercent)
+                            );
                         }
                     }
             ).addModifier(Modifier.ON_OUTGOING_SHIELD_DAMAGE, (event, currentDamageValue, isCrit) -> {

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ArcaneShatter.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ArcaneShatter.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Sound;
@@ -65,8 +66,8 @@ public class ArcaneShatter implements SpecBoostManager.SpecBoost<ArcaneShatter> 
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
-            warlordsPlayer.getEnergyPerHit().addAdditiveModifier("Spec Boost", energyPerMelee);
-            warlordsPlayer.getHealth().addAdditiveModifier("Spec Boost (Base)", healthIncrease);
+            warlordsPlayer.getEnergyPerHit().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", energyPerMelee);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost (Base)", healthIncrease);
         }
 
         @Override
@@ -104,7 +105,10 @@ public class ArcaneShatter implements SpecBoostManager.SpecBoost<ArcaneShatter> 
                         cM -> {},
                         stunTicks
                 ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (e, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToMultiplicationDecimal(damageIncrease));
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                            getStringName(),
+                            AbstractAbility.convertToMultiplicationDecimal(damageIncrease)
+                    );
                         }
                 ));
             });

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ArmOfTheAlmighty.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ArmOfTheAlmighty.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -75,7 +76,10 @@ public class ArmOfTheAlmighty implements SpecBoostManager.SpecBoost<ArmOfTheAlmi
                         if (!(event.getAbility() instanceof AvengersStrike) || !warlordsPlayer.getCooldownManager().hasCooldown(AvengersWrath.AvengersWrathData.class)) {
                             return;
                         }
-                        currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToMultiplicationDecimal(wrathDamageBoostPercent));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        getStringName(),
+                        AbstractAbility.convertToMultiplicationDecimal(wrathDamageBoostPercent)
+                );
                     }
             ));
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AugmentedChains.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AugmentedChains.java
@@ -7,6 +7,7 @@ import com.ebicep.warlords.events.player.ingame.WarlordsDamageHealingFinalEvent;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.HashSet;
@@ -59,13 +60,13 @@ public class AugmentedChains implements SpecBoostManager.SpecBoost<AugmentedChai
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(ChainHeal.class).forEach(chainHeal -> {
                 chainHeal.getHealValues().getChainHealing().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", chainHealHealingIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", chainHealHealingIncreasePercent / 100)
                 );
-                chainHeal.getEnergyCost().addAdditiveModifier("Spec Boost", -chainHealEnergyCostDecrease);
+                chainHeal.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -chainHealEnergyCostDecrease);
             });
             warlordsPlayer.getAbilitiesMatching(Boulder.class).forEach(boulder -> {
                 boulder.getDamageValues().getBoulderDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", -boulderDamageDecreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -boulderDamageDecreasePercent / 100)
                 );
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AuraOfRestoration.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AuraOfRestoration.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.Collections;
@@ -61,9 +62,11 @@ public class AuraOfRestoration implements SpecBoostManager.SpecBoost<AuraOfResto
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(SoothingElixir.class).forEach(soothingElixir -> {
-                soothingElixir.getCooldown().addAdditiveModifier("Spec Boost", soothingElixirCooldownIncreaseSeconds);
+                soothingElixir.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", soothingElixirCooldownIncreaseSeconds);
                 soothingElixir.getHealValues().getElixirDOTHealing()
-                              .forEachValue(floatModifiable -> floatModifiable.addMultiplicativeModifierAdd("Spec Boost", puddleHealingIncreasePercent / 100));
+                              .forEachValue(floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                                      "Spec Boost", puddleHealingIncreasePercent / 100
+                              ));
             });
             warlordsPlayer.getAbilitiesMatching(RemedicChains.class).forEach(remedicChains -> {
                 remedicChains.setLinkBreakRadius((int) (remedicChains.getLinkBreakRadius() + remedicChainsBreakRadiusIncrease));

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BigGuy.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BigGuy.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.ProtectorsStrike;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -45,8 +46,8 @@ public class BigGuy implements SpecBoostManager.SpecBoost<BigGuy> {
 
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
-            warlordsPlayer.getHealth().addAdditiveModifier("Spec Boost (Base)", healthIncrease);
-            warlordsPlayer.getEnergy().addAdditiveModifier("Spec Boost", maxEnergyIncrease);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost (Base)", healthIncrease);
+            warlordsPlayer.getEnergy().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", maxEnergyIncrease);
             warlordsPlayer.getAbilitiesMatching(ProtectorsStrike.class).forEach(protectorsStrike -> {
                 protectorsStrike.setSelfHealing(strikeSelfHealingPercent);
                 protectorsStrike.setAllyHealing(strikeAllyHealingPercent);

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BlizzardBreath.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BlizzardBreath.java
@@ -1,10 +1,10 @@
 package com.ebicep.warlords.player.general.specboosts.boosts;
 
-import com.ebicep.warlords.abilities.internal.AbstractArcaneShield;
 import com.ebicep.warlords.abilities.FreezingBreath;
 import com.ebicep.warlords.abilities.TimeSurge;
 import com.ebicep.warlords.abilities.TimeWarpCryomancer;
 import com.ebicep.warlords.abilities.internal.AbstractAbility;
+import com.ebicep.warlords.abilities.internal.AbstractArcaneShield;
 import com.ebicep.warlords.events.player.ingame.WarlordsAbilityActivateEvent;
 import com.ebicep.warlords.events.player.ingame.WarlordsDamageHealingEvent;
 import com.ebicep.warlords.events.player.ingame.WarlordsDamageHealingFinalEvent;
@@ -14,6 +14,7 @@ import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.TextComponent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -79,14 +80,14 @@ public class BlizzardBreath implements SpecBoostManager.SpecBoost<BlizzardBreath
             }
             warlordsPlayer.resetAbilityTree();
             warlordsPlayer.getAbilitiesMatching(AbstractArcaneShield.class).forEach(arcaneShield -> {
-                arcaneShield.getCooldown().addMultiplicativeModifierAdd("Spec Boost", -productionValuesDecreasePercent / 100.0f);
-                arcaneShield.getEnergyCost().addMultiplicativeModifierAdd("Spec Boost", -productionValuesDecreasePercent / 100.0f);
+                arcaneShield.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -productionValuesDecreasePercent / 100.0f);
+                arcaneShield.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -productionValuesDecreasePercent / 100.0f);
                 arcaneShield.setShieldPercentage(arcaneShield.getShieldPercentage() * AbstractAbility.convertToDivisionDecimal(productionValuesDecreasePercent));
                 arcaneShield.updateCustomStats(warlordsPlayer);
             });
             warlordsPlayer.getAbilitiesMatching(TimeSurge.class).forEach(timeSurge -> {
-                timeSurge.getCooldown().addMultiplicativeModifierAdd("Spec Boost", -productionValuesDecreasePercent / 100.0f);
-                timeSurge.getEnergyCost().addMultiplicativeModifierAdd("Spec Boost", -productionValuesDecreasePercent / 100.0f);
+                timeSurge.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -productionValuesDecreasePercent / 100.0f);
+                timeSurge.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -productionValuesDecreasePercent / 100.0f);
                 timeSurge.setHealPercentage(timeSurge.getHealPercentage() * AbstractAbility.convertToDivisionDecimal(productionValuesDecreasePercent));
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BloodFrenzy.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BloodFrenzy.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
 import com.ebicep.warlords.player.ingame.instances.type.CustomInstanceFlags;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -59,9 +60,9 @@ public class BloodFrenzy implements SpecBoostManager.SpecBoost<BloodFrenzy> {
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(BloodLust.class).forEach(bloodLust -> {
-                bloodLust.getCooldown().addAdditiveModifier("Spec Boost", -bloodLustCooldownReductionTicks / 20f);
+                bloodLust.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -bloodLustCooldownReductionTicks / 20f);
                 bloodLust.setTickDuration(bloodLust.getTickDuration() - bloodLustDurationReductionTicks);
-                bloodLust.getEnergyCost().addAdditiveModifier("Spec Boost", -bloodLustEnergyCostReduction);
+                bloodLust.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -bloodLustEnergyCostReduction);
                 bloodLust.setDamageConvertPercent(bloodLust.getDamageConvertPercent() - (int) bloodLustHealingPercent);
             });
         }
@@ -81,7 +82,7 @@ public class BloodFrenzy implements SpecBoostManager.SpecBoost<BloodFrenzy> {
                 if (customFlag instanceof CustomInstanceFlags.FinalEventInstanceFlag(WarlordsDamageHealingFinalEvent finalEvent)) {
                     float additionalHealing = finalEvent.getValueBeforeAllReduction() * bloodLustHealingPiercePercent / 100f;
                     event.applyToMinMax(floatModifiable ->
-                            floatModifiable.addAdditiveModifier(getStringName(), additionalHealing)
+                            floatModifiable.addModifier(FloatModifiable.ModifierType.ADDITIVE, getStringName(), additionalHealing)
                     );
                     return;
                 }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BurstChain.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BurstChain.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.AbstractCooldown;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.*;
@@ -71,10 +72,10 @@ public class BurstChain implements SpecBoostManager.SpecBoost<BurstChain> {
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
-            warlordsPlayer.getHealth().addAdditiveModifier("Spec Boost (Base)", -healthDecrease);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost (Base)", -healthDecrease);
             warlordsPlayer.getSpeed().addBaseModifier(baseSpeedIncreasePercent);
             warlordsPlayer.getAbilitiesMatching(FlameBurst.class).forEach(flameBurst -> {
-                flameBurst.getProjectileSpeed().addMultiplicativeModifierAdd("Spec Boost", (velocityIncreasePercentage + 100) / 100);
+                flameBurst.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", (velocityIncreasePercentage + 100) / 100);
             });
             warlordsPlayer.getCooldownManager().addCooldown(new PermanentCooldown<>(
                     getStringName(),
@@ -95,7 +96,7 @@ public class BurstChain implements SpecBoostManager.SpecBoost<BurstChain> {
                                   .noneMatch(damageReductionAbilities::contains)
                         ) {
                             boolean hasInferno = warlordsPlayer.getCooldownManager().hasCooldown(Inferno.class);
-                            currentDamageValue.addMultiplicativeModifierMult(getStringName(),
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getStringName(),
                                     AbstractAbility.convertToMultiplicationDecimal(hasInferno ? infernoDamageIncreasePercent :
                                                                                    damageIncreasePercent)
                             );
@@ -117,7 +118,7 @@ public class BurstChain implements SpecBoostManager.SpecBoost<BurstChain> {
                 return;
             }
             flameBurstHit.put(event.getUUID(), (hitCount == null ? 0 : hitCount) + 1);
-            event.getCritChance().addOverridingModifier(getStringName(), 100);
+            event.getCritChance().addModifier(FloatModifiable.ModifierType.OVERRIDING, getStringName(), 100);
         }
 
     }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Clairvoyance.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Clairvoyance.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.abilities.TimeWarpAquamancer;
 import com.ebicep.warlords.abilities.internal.AbstractAbility;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.TextComponent;
 
 import java.util.List;
@@ -52,7 +53,7 @@ public class Clairvoyance implements SpecBoostManager.SpecBoost<Clairvoyance> {
 
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
-            warlordsPlayer.getEnergy().addAdditiveModifier("Spec Boost", maxEnergyIncrease);
+            warlordsPlayer.getEnergy().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", maxEnergyIncrease);
             List<AbstractAbility> abilities = warlordsPlayer.getAbilities();
             for (int i = 0; i < abilities.size(); i++) {
                 AbstractAbility ability = abilities.get(i);
@@ -63,7 +64,7 @@ public class Clairvoyance implements SpecBoostManager.SpecBoost<Clairvoyance> {
                 } else if (ability instanceof HealingRain healingRain) {
                     healingRain.setTickDuration(healingRain.getTickDuration() - healingRainDurationDecreaseTicks);
                     healingRain.getHealValues().getRainHealing().forEachValue(floatModifiable ->
-                            floatModifiable.addMultiplicativeModifierAdd("Spec Boost", healingRainHealIncreasePercent / 100)
+                            floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", healingRainHealIncreasePercent / 100)
                     );
                 }
             }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Conduit.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Conduit.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.AvengersStrike;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -43,7 +44,7 @@ public class Conduit implements SpecBoostManager.SpecBoost<Conduit> {
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(AvengersStrike.class).forEach(avengerStrike -> {
                 avengerStrike.getDamageValues().getStrikeDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", avengerStrikeDamageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", avengerStrikeDamageIncreasePercent / 100)
                 );
                 avengerStrike.setEnergySteal(avengerStrike.getEnergySteal() + energyRemovalIncrease);
             });

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ConsecratedBeacon.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ConsecratedBeacon.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.SanctifiedBeacon;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -44,8 +45,8 @@ public class ConsecratedBeacon implements SpecBoostManager.SpecBoost<Consecrated
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(SanctifiedBeacon.class).forEach(sanctifiedBeacon -> {
-                sanctifiedBeacon.getEnergyCost().addAdditiveModifier("Spec Boost", -sanctifiedBeaconEnergyCostDecrease);
-                sanctifiedBeacon.getCooldown().addMultiplicativeModifierAdd("Spec Boost", -sanctifiedBeaconCooldownReductionPercent / 100);
+                sanctifiedBeacon.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -sanctifiedBeaconEnergyCostDecrease);
+                sanctifiedBeacon.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -sanctifiedBeaconCooldownReductionPercent / 100);
                 sanctifiedBeacon.setStacksGranted(sanctifiedBeacon.getStacksGranted() + sanctifiedBeaconAdditionalHexStacks);
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Contagion.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Contagion.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.ContagiousFacade;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -43,9 +44,9 @@ public class Contagion implements SpecBoostManager.SpecBoost<Contagion> {
 
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
-            warlordsPlayer.getEnergyPerHit().addAdditiveModifier("Spec Boost", ephIncrease);
+            warlordsPlayer.getEnergyPerHit().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", ephIncrease);
             warlordsPlayer.getAbilitiesMatching(ContagiousFacade.class).forEach(contagiousFacade -> {
-                contagiousFacade.getDamageAbsorption().addAdditiveModifier("Spec Boost", facadeResistanceIncreasePercent);
+                contagiousFacade.getDamageAbsorption().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", facadeResistanceIncreasePercent);
                 contagiousFacade.setStacksGranted(contagiousFacade.getStacksGranted() + facadePhexStacksIncrease);
                 contagiousFacade.setReactivateAbility(false);
             });

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/CrusadersMight.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/CrusadersMight.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.CrusadersStrike;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -41,7 +42,7 @@ public class CrusadersMight implements SpecBoostManager.SpecBoost<CrusadersMight
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(CrusadersStrike.class).forEach(crusaderStrike -> {
                 crusaderStrike.getDamageValues().getStrikeDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", damageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", damageIncreasePercent / 100)
                 );
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/DimensionalWarp.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/DimensionalWarp.java
@@ -14,6 +14,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Sound;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -70,7 +71,7 @@ public class DimensionalWarp implements SpecBoostManager.SpecBoost<DimensionalWa
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
-            warlordsPlayer.getEnergy().addAdditiveModifier("Spec Boost", maxEnergyGain);
+            warlordsPlayer.getEnergy().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", maxEnergyGain);
             warlordsPlayer.getAbilitiesMatching(TimeWarpPyromancer.class).forEach(timeWarp -> {
                 timeWarp.setTickDuration(timeWarp.getTickDuration() - ticks);
             });
@@ -88,7 +89,10 @@ public class DimensionalWarp implements SpecBoostManager.SpecBoost<DimensionalWa
             cooldown.getFlags().add(CooldownFlag.CANNOT_BE_REDUCED_VIND);
             warlordsEntity.addSpeedModifier(warlordsEntity, getStringName(), speedIncrease, cooldown);
             cooldown.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (e, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToMultiplicationDecimal(damageIncrease));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        getStringName(),
+                        AbstractAbility.convertToMultiplicationDecimal(damageIncrease)
+                );
                     }
             );
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/DivineEffulgence.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/DivineEffulgence.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -67,9 +68,9 @@ public class DivineEffulgence implements SpecBoostManager.SpecBoost<DivineEffulg
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(HolyRadianceProtector.class).forEach(holyRadiance -> {
                 holyRadiance.getHealValues().getRadianceHealing().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", holyRadianceHealingIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", holyRadianceHealingIncreasePercent / 100)
                 );
-                holyRadiance.getSpeed().addMultiplicativeModifierAdd("Spec Boost", holyRadianceTravelSpeedPercentIncrease / 100);
+                holyRadiance.getSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", holyRadianceTravelSpeedPercentIncrease / 100);
             });
         }
 
@@ -95,7 +96,10 @@ public class DivineEffulgence implements SpecBoostManager.SpecBoost<DivineEffulg
                     rangedDamageReductionDurationTicks
             ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (e, currentDamageValue) -> {
                         if (Utils.isProjectile(e.getCause()) || isCustomProjectile(e.getCause())) {
-                            currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToDivisionDecimal(rangedDamageReductionPercent));
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                    getStringName(),
+                                    AbstractAbility.convertToDivisionDecimal(rangedDamageReductionPercent)
+                            );
                         }
                     }
             ));

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/DivinePurification.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/DivinePurification.java
@@ -1,7 +1,7 @@
 package com.ebicep.warlords.player.general.specboosts.boosts;
 
-import com.ebicep.warlords.abilities.internal.AbstractArcaneShield;
 import com.ebicep.warlords.abilities.WaterBreath;
+import com.ebicep.warlords.abilities.internal.AbstractArcaneShield;
 import com.ebicep.warlords.events.player.ingame.WarlordsDamageHealingFinalEvent;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
@@ -9,6 +9,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownUtils;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -62,11 +63,11 @@ public class DivinePurification implements SpecBoostManager.SpecBoost<DivinePuri
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(WaterBreath.class).forEach(waterBreath -> {
-                waterBreath.getCooldown().addMultiplicativeModifierAdd("Spec Boost", -waterBreathCooldownReductionPercent / 100f);
-                waterBreath.getEnergyCost().addMultiplicativeModifierAdd("Spec Boost", -waterBreathEnergyCostReductionPercent / 100f);
+                waterBreath.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -waterBreathCooldownReductionPercent / 100f);
+                waterBreath.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -waterBreathEnergyCostReductionPercent / 100f);
             });
             warlordsPlayer.getAbilitiesMatching(AbstractArcaneShield.class).forEach(arcaneShield -> {
-                arcaneShield.getEnergyCost().addOverridingModifier("Spec Boost", arcaneShieldEnergyCost);
+                arcaneShield.getEnergyCost().addModifier(FloatModifiable.ModifierType.OVERRIDING, "Spec Boost", arcaneShieldEnergyCost);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Downpour.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Downpour.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.abilities.WaterBolt;
 import com.ebicep.warlords.abilities.WaterBreath;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -61,7 +62,7 @@ public class Downpour implements SpecBoostManager.SpecBoost<Downpour> {
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(WaterBolt.class).forEach(waterBolt -> {
-                waterBolt.getProjectileSpeed().addMultiplicativeModifierAdd("Spec Boost", (waterBoltSpeedIncreasePercent + 100) / 100);
+                waterBolt.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", (waterBoltSpeedIncreasePercent + 100) / 100);
                 waterBolt.setMaxFullDistance((int) waterBolt.getMaxDistance().getCalculatedValue());
             });
             warlordsPlayer.getAbilitiesMatching(WaterBreath.class).forEach(waterBreath -> {
@@ -69,12 +70,12 @@ public class Downpour implements SpecBoostManager.SpecBoost<Downpour> {
             });
             warlordsPlayer.getAbilitiesMatching(HealingRain.class).forEach(healingRain -> {
                 healingRain.setMaxCharges(healingRainMaxCharges);
-                healingRain.getCooldown().addMultiplicativeModifierAdd("Spec Boost", -healingRainCooldownReductionPercent / 100);
+                healingRain.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -healingRainCooldownReductionPercent / 100);
                 healingRain.getHealValues().getRainHealing().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", healingRainHealingIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", healingRainHealingIncreasePercent / 100)
                 );
                 healingRain.setTickDuration(Math.round(healingRain.getTickDuration() * (1 - healingRainDurationDecreasePercent / 100)));
-                healingRain.getHitBoxRadius().addAdditiveModifier("Spec Boost", -healingRainRadiusDecreaseBlocks);
+                healingRain.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -healingRainRadiusDecreaseBlocks);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/DrainingMiasma.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/DrainingMiasma.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.abilities.VolatileBrew;
 import com.ebicep.warlords.abilities.internal.AbstractAbility;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.TextComponent;
 
 import java.util.List;
@@ -52,7 +53,7 @@ public class DrainingMiasma implements SpecBoostManager.SpecBoost<DrainingMiasma
                 if (ability instanceof VolatileBrew) {
                     com.ebicep.warlords.abilities.DrainingMiasma drainingMiasma = new com.ebicep.warlords.abilities.DrainingMiasma();
                     drainingMiasma.init(drainingMiasma.getBuilder());
-                    drainingMiasma.getCooldown().addMultiplicativeModifierAdd("Spec Boost", -drainingMiasmaCooldownReductionPercent / 100);
+                    drainingMiasma.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -drainingMiasmaCooldownReductionPercent / 100);
                     abilities.set(i, drainingMiasma);
                 }
             }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/EarthboundInfusion.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/EarthboundInfusion.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.CustomInstanceFlags;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -66,9 +67,9 @@ public class EarthboundInfusion implements SpecBoostManager.SpecBoost<Earthbound
 
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
-            warlordsPlayer.getHealth().addAdditiveModifier("Spec Boost (Base)", healthIncrease);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost (Base)", healthIncrease);
             warlordsPlayer.getAbilitiesMatching(EarthlivingWeapon.class).forEach(earthlivingWeapon -> {
-                earthlivingWeapon.getCooldown().addAdditiveModifier("Spec Boost", -earthlivingCooldownReductionSeconds);
+                earthlivingWeapon.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -earthlivingCooldownReductionSeconds);
                 earthlivingWeapon.setTickDuration(earthlivingWeapon.getTickDuration() - earthlivingDurationDecreaseTicks);
                 earthlivingWeapon.setGuaranteedHits(earthlivingWeapon.getGuaranteedHits() + earthlivingExtraGuaranteedHits);
             });
@@ -89,7 +90,7 @@ public class EarthboundInfusion implements SpecBoostManager.SpecBoost<Earthbound
                             List<CustomInstanceFlags> customFlags = event.getCustomFlags();
                             for (CustomInstanceFlags customFlag : customFlags) {
                                 if (customFlag instanceof CustomInstanceFlags.PlayersEffectedInstanceFlag(List<WarlordsEntity> healedPlayers) && healedPlayers.isEmpty()) {
-                                    currentHealValue.addAdditiveModifier(getStringName(), earthlivingSingleHealBonus);
+                                    currentHealValue.addModifier(FloatModifiable.ModifierType.ADDITIVE, getStringName(), earthlivingSingleHealBonus);
                                 }
                             }
                         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/EcoDrive.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/EcoDrive.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.CustomInstanceFlags;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -51,10 +52,10 @@ public class EcoDrive implements SpecBoostManager.SpecBoost<EcoDrive> {
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(LightInfusionProtector.class).forEach(lightInfusion -> {
-                lightInfusion.getCooldown().addAdditiveModifier("Spec Boost", -lightInfusionCooldownReductionTicks / 20f);
+                lightInfusion.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -lightInfusionCooldownReductionTicks / 20f);
             });
             warlordsPlayer.getAbilitiesMatching(HolyRadianceProtector.class).forEach(holyRadiance -> {
-                holyRadiance.getEnergyCost().addAdditiveModifier("Spec Boost", -holyRadianceEnergyCost);
+                holyRadiance.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -holyRadianceEnergyCost);
             });
             warlordsPlayer.getCooldownManager().addCooldown(new PermanentCooldown<>(
                     getStringName(),
@@ -71,7 +72,7 @@ public class EcoDrive implements SpecBoostManager.SpecBoost<EcoDrive> {
                             List<CustomInstanceFlags> customFlags = event.getCustomFlags();
                             for (CustomInstanceFlags customFlag : customFlags) {
                                 if (customFlag instanceof CustomInstanceFlags.PlayersEffectedInstanceFlag(List<WarlordsEntity> healedPlayers) && healedPlayers.size() == 1) {
-                                    currentHealValue.addMultiplicativeModifierMult(getStringName(), 1 + singleAllyHealBonusPercent / 100);
+                                    currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getStringName(), 1 + singleAllyHealBonusPercent / 100);
                                 }
                             }
                         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/EfficientStrikes.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/EfficientStrikes.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.WoundingStrikeBerserker;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -40,7 +41,7 @@ public class EfficientStrikes implements SpecBoostManager.SpecBoost<EfficientStr
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(WoundingStrikeBerserker.class).forEach(woundingStrike -> {
-                woundingStrike.getEnergyCost().addAdditiveModifier("Spec Boost", -woundingStrikeEnergyCostReduction);
+                woundingStrike.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -woundingStrikeEnergyCostReduction);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ElectromagneticChains.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ElectromagneticChains.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -58,12 +59,12 @@ public class ElectromagneticChains implements SpecBoostManager.SpecBoost<Electro
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(LightningBolt.class).forEach(lightningBolt -> {
                 lightningBolt.getDamageValues().getBoltDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", -damageReductionPercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -damageReductionPercent / 100)
                 );
             });
             warlordsPlayer.getAbilitiesMatching(ChainLightning.class).forEach(chainLightning -> {
                 chainLightning.getDamageValues().getChainDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", -damageReductionPercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -damageReductionPercent / 100)
                 );
             });
         }
@@ -88,7 +89,10 @@ public class ElectromagneticChains implements SpecBoostManager.SpecBoost<Electro
                     cooldownManager -> {},
                     chainLightningDurationTicks
             ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (e, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToDivisionDecimal(chainLightningDamageReductionPercent));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        getStringName(),
+                        AbstractAbility.convertToDivisionDecimal(chainLightningDamageReductionPercent)
+                );
                     }
             ));
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/EnergyOversurge.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/EnergyOversurge.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.EnergySeerLuminary;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -44,7 +45,7 @@ public class EnergyOversurge implements SpecBoostManager.SpecBoost<EnergyOversur
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(EnergySeerLuminary.class).forEach(energySeer -> {
-                energySeer.getCooldown().addMultiplicativeModifierAdd("Spec Boost", -energySeerCooldownReductionPercent / 100);
+                energySeer.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -energySeerCooldownReductionPercent / 100);
                 energySeer.setEnergyRestore(energySeer.getEnergyRestore() + energySeerAdditionalEnergyGrant);
                 energySeer.setEpsDecrease((int) (energySeer.getEpsDecrease() * (1 + energyLostIncreasePercent / 100)));
             });

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/EyeOfTheStorm.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/EyeOfTheStorm.java
@@ -15,6 +15,7 @@ import com.ebicep.warlords.util.bukkit.LocationBuilder;
 import com.ebicep.warlords.util.bukkit.LocationUtils;
 import com.ebicep.warlords.util.java.MathUtils;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -79,9 +80,9 @@ public class EyeOfTheStorm implements SpecBoostManager.SpecBoost<EyeOfTheStorm> 
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(LightningBolt.class).forEach(lightningBolt -> {
-                lightningBolt.getMaxDistance().addOverridingModifier("Spec Boost", maxTravelBlocks);
-                lightningBolt.getProjectileSpeed().addMultiplicativeModifierAdd("Spec Boost", (velocityIncreasePercentage + 100) / 100);
-                lightningBolt.getSplashRadius().addOverridingModifier("Spec Boost", splashRadiusBlocks);
+                lightningBolt.getMaxDistance().addModifier(FloatModifiable.ModifierType.OVERRIDING, "Spec Boost", maxTravelBlocks);
+                lightningBolt.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", (velocityIncreasePercentage + 100) / 100);
+                lightningBolt.getSplashRadius().addModifier(FloatModifiable.ModifierType.OVERRIDING, "Spec Boost", splashRadiusBlocks);
                 lightningBolt.setCooldownReduction(lightningBolt.getCooldownReduction() + chainCooldownReductionIncrease);
             });
             warlordsPlayer.getAbilitiesMatching(LightningRod.class).forEach(lightningRod -> {

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/FerventForce.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/FerventForce.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.abilities.GroundSlamDefender;
 import com.ebicep.warlords.abilities.SeismicWaveDefender;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -43,10 +44,10 @@ public class FerventForce implements SpecBoostManager.SpecBoost<FerventForce> {
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(SeismicWaveDefender.class).forEach(seismicWave -> {
-                seismicWave.getCooldown().addMultiplicativeModifierAdd("Spec Boost", -seismicWaveCooldownReductionPercent / 100);
+                seismicWave.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -seismicWaveCooldownReductionPercent / 100);
             });
             warlordsPlayer.getAbilitiesMatching(GroundSlamDefender.class).forEach(groundSlam -> {
-                groundSlam.getCooldown().addMultiplicativeModifierAdd("Spec Boost", -groundSlamCooldownReductionPercent / 100);
+                groundSlam.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -groundSlamCooldownReductionPercent / 100);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/FortifiedAegis.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/FortifiedAegis.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.AbstractCooldown;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownManager;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.event.EventHandler;
@@ -60,9 +61,9 @@ public class FortifiedAegis implements SpecBoostManager.SpecBoost<FortifiedAegis
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
-            warlordsPlayer.getHealth().addAdditiveModifier("Spec Boost (Base)", healthIncrease);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost (Base)", healthIncrease);
             warlordsPlayer.getAbilitiesMatching(AbstractArcaneShield.class).forEach(arcaneShield -> {
-                arcaneShield.getCooldown().addAdditiveModifier("Spec Boost", -arcaneShieldCooldownReductionSeconds);
+                arcaneShield.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -arcaneShieldCooldownReductionSeconds);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/FrostMissile.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/FrostMissile.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.FrostBolt;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -46,10 +47,13 @@ public class FrostMissile implements SpecBoostManager.SpecBoost<FrostMissile> {
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(FrostBolt.class).forEach(frostBolt -> {
-                frostBolt.getEnergyCost().addAdditiveModifier("Spec Boost", -energyDecrease);
+                frostBolt.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -energyDecrease);
                 frostBolt.getDamageValues()
                          .getBoltDamage()
-                         .forEachValue(floatModifiable -> floatModifiable.addMultiplicativeModifierAdd("Spec Boost", -damageDecreasePercent / 100));
+                         .forEachValue(floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                                 "Spec Boost",
+                                 -damageDecreasePercent / 100
+                         ));
                 frostBolt.setSlowness(frostBolt.getSlowness() + slowIncrease);
                 frostBolt.setDirectHitAdditionalSlowness(frostBolt.getDirectHitAdditionalSlowness() + directHitSlowIncrease);
             });

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/GalvanizedSpark.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/GalvanizedSpark.java
@@ -7,6 +7,7 @@ import com.ebicep.warlords.events.player.ingame.WarlordsAbilityActivateEvent;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -74,7 +75,7 @@ public class GalvanizedSpark implements SpecBoostManager.SpecBoost<GalvanizedSpa
             warlordsPlayer.getAbilitiesMatching(LightningRod.class).forEach(lightningRod -> {
                 lightningRod.setMaxCharges(lightningRodMaxAbilityCharges);
                 lightningRod.setCurrentCharges(lightningRodMaxAbilityCharges);
-                lightningRod.getCooldown().addAdditiveModifier("Spec Boost", -lightningRodCooldownDecreaseSeconds);
+                lightningRod.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -lightningRodCooldownDecreaseSeconds);
                 lightningRod.getHealValues().getHealthRestore().value().setBaseValue(lightningRod.getHealValues().getHealthRestore().getValue() - lightningRodHealingDecreasePercent);
                 lightningRod.setEnergyRestore(lightningRod.getEnergyRestore() - lightningRodEnergyRestoreDecrease);
                 lightningRod.setMagnitude(lightningRodMagnitude);
@@ -83,7 +84,10 @@ public class GalvanizedSpark implements SpecBoostManager.SpecBoost<GalvanizedSpa
             warlordsPlayer.getAbilitiesMatching(CapacitorTotem.class).forEach(capacitorTotem -> {
                 capacitorTotem.getDamageValues()
                               .getTotemDamage()
-                              .forEachValue(floatModifiable -> floatModifiable.addMultiplicativeModifierAdd("Spec Boost", -capacitorTotemDamageDecreasePercent / 100));
+                              .forEachValue(floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                                      "Spec Boost",
+                                      -capacitorTotemDamageDecreasePercent / 100
+                              ));
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Goliath.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Goliath.java
@@ -7,6 +7,7 @@ import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -53,10 +54,10 @@ public class Goliath implements SpecBoostManager.SpecBoost<Goliath> {
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
-            warlordsPlayer.getHealth().addAdditiveModifier("Spec Boost (Base)", healthIncrease);
-            warlordsPlayer.getEnergy().addAdditiveModifier("Spec Boost", maxEnergyIncrease);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost (Base)", healthIncrease);
+            warlordsPlayer.getEnergy().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", maxEnergyIncrease);
             warlordsPlayer.getAbilitiesMatching(Berserk.class).forEach(berserk -> {
-                berserk.getCooldown().addAdditiveModifier("Spec Boost", berserkCooldownIncreaseTicks / 20f);
+                berserk.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", berserkCooldownIncreaseTicks / 20f);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/HammerOfJudgement.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/HammerOfJudgement.java
@@ -15,6 +15,7 @@ import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 
@@ -78,7 +79,7 @@ public class HammerOfJudgement implements SpecBoostManager.SpecBoost<HammerOfJud
                         return cons;
                     });
             warlordsPlayer.getAbilitiesMatching(HammerOfLight.class).forEach(hammerOfLight -> {
-                hammerOfLight.getCooldown().addAdditiveModifier("Spec Boost", hammerOfLightCooldownIncreaseTicks / 20f);
+                hammerOfLight.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", hammerOfLightCooldownIncreaseTicks / 20f);
             });
         }
 
@@ -141,7 +142,9 @@ public class HammerOfJudgement implements SpecBoostManager.SpecBoost<HammerOfJud
                                                 }
                                                 e.getFlags().add(InstanceFlags.STRIKE_IN_CONS);
                                                 consecrateProtector.addStrikesBoosted();
-                                                currentDamageValue.addMultiplicativeModifierMult(cooldownName, convertToMultiplicationDecimal(consecrateProtector.getStrikeDamageBoost()));
+                                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                                cooldownName, convertToMultiplicationDecimal(consecrateProtector.getStrikeDamageBoost())
+                                        );
                                             }
                                     ));
                                 }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/HealingLink.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/HealingLink.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.abilities.RecklessCharge;
 import com.ebicep.warlords.abilities.internal.AbstractAbility;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.TextComponent;
 
 import java.util.List;
@@ -55,7 +56,7 @@ public class HealingLink implements SpecBoostManager.SpecBoost<HealingLink> {
                     healingLink.init(healingLink.getBuilder());
                     abilities.set(i, healingLink);
                 } else if (ability instanceof GroundSlamRevenant groundSlam) {
-                    groundSlam.getCooldown().addAdditiveModifier("Spec Boost", -groundSlamCooldownReductionTicks / 20f);
+                    groundSlam.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -groundSlamCooldownReductionTicks / 20f);
                 }
             }
             warlordsPlayer.resetAbilityTree();

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/HolyNova.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/HolyNova.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -77,7 +78,10 @@ public class HolyNova implements SpecBoostManager.SpecBoost<HolyNova> {
                         if (e.getCause().equals("Divine Blessing") &&
                                 e.getWarlordsEntity().getLocation().distanceSquared(warlordsEntity.getLocation()) > divineBlessingFarRangeBlocks * divineBlessingFarRangeBlocks
                         ) {
-                            currentHealValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToMultiplicationDecimal(divineBlessingHealingIncreasePercentFar));
+                            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                    getStringName(),
+                                    AbstractAbility.convertToMultiplicationDecimal(divineBlessingHealingIncreasePercentFar)
+                            );
                         }
                     }
             );

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/HouseOfLife.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/HouseOfLife.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.EnergySeerConjurer;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -46,12 +47,12 @@ public class HouseOfLife implements SpecBoostManager.SpecBoost<HouseOfLife> {
 
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
-            warlordsPlayer.getHealth().addAdditiveModifier("Spec Boost (Base)", healthIncrease);
-            warlordsPlayer.getEnergy().addAdditiveModifier("Spec Boost", energyIncrease);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost (Base)", healthIncrease);
+            warlordsPlayer.getEnergy().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", energyIncrease);
 
             warlordsPlayer.getAbilitiesMatching(EnergySeerConjurer.class).forEach(energySeer -> {
                 energySeer.getHealValues().getSeerHealingMultiplier().forEachValue(floatModifiable ->
-                        floatModifiable.addOverridingModifier("Spec Boost", energySeerHealingMultiplier / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.OVERRIDING, "Spec Boost", energySeerHealingMultiplier / 100)
                 );
                 energySeer.setEnergyRestore(energySeer.getEnergyRestore() + energySeerEnergyIncrease);
             });

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/IceBlock.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/IceBlock.java
@@ -14,6 +14,7 @@ import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.player.ingame.motionsystem.MotionModifierBuilder;
 import com.ebicep.warlords.player.ingame.motionsystem.speed.OverrideValueModifier;
 import com.ebicep.warlords.util.bukkit.LocationBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
@@ -174,7 +175,10 @@ public class IceBlock implements SpecBoostManager.SpecBoost<IceBlock> {
                             }
                         };
                         cd.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (e, currentDamageValue) -> {
-                                    currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToDivisionDecimal(recastDamageReductionPercent));
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                    getStringName(),
+                                    AbstractAbility.convertToDivisionDecimal(recastDamageReductionPercent)
+                            );
                                 }
                         );
                         blockCooldown.set(cd);

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/LustrousCrown.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/LustrousCrown.java
@@ -7,6 +7,7 @@ import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.AbstractCooldown;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -52,7 +53,7 @@ public class LustrousCrown implements SpecBoostManager.SpecBoost<LustrousCrown> 
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(HammerOfLight.class).forEach(hammerOfLight -> {
-                hammerOfLight.getCrownRadius().addAdditiveModifier("Spec Boost", crownOfLightRadiusIncrease);
+                hammerOfLight.getCrownRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", crownOfLightRadiusIncrease);
                 hammerOfLight.setCrownBonusHealing(hammerOfLight.getCrownBonusHealing() + crownOfLightHealingIncreasePercent);
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MarkedForDeath.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MarkedForDeath.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -76,8 +77,8 @@ public class MarkedForDeath implements SpecBoostManager.SpecBoost<MarkedForDeath
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(HolyRadianceAvenger.class).forEach(holyRadiance -> {
-                holyRadiance.getCooldown().addAdditiveModifier("Spec Boost", -holyRadianceCooldownReductionTicks / 20f);
-                holyRadiance.getEnergyCost().addOverridingModifier("Spec Boost", holyRadianceEnergyCost);
+                holyRadiance.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -holyRadianceCooldownReductionTicks / 20f);
+                holyRadiance.getEnergyCost().addModifier(FloatModifiable.ModifierType.OVERRIDING, "Spec Boost", holyRadianceEnergyCost);
             });
         }
 
@@ -101,7 +102,10 @@ public class MarkedForDeath implements SpecBoostManager.SpecBoost<MarkedForDeath
             );
             target.addSpeedModifier(warlordsEntity, getStringName(), -avengerMarkSlowPercent, regularCooldown);
             regularCooldown.addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (e, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToMultiplicationDecimal(avengerMarkIncreaseDamagePercent));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        getStringName(),
+                        AbstractAbility.convertToMultiplicationDecimal(avengerMarkIncreaseDamagePercent)
+                );
                     }
             );
             final int[] ticksIncreased = {0};

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MegalithicBoulder.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MegalithicBoulder.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.abilities.Boulder;
 import com.ebicep.warlords.abilities.ChainHeal;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -44,7 +45,7 @@ public class MegalithicBoulder implements SpecBoostManager.SpecBoost<MegalithicB
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(Boulder.class).forEach(boulder -> {
                 boulder.getDamageValues().getBoulderDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", boulderDamageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", boulderDamageIncreasePercent / 100)
                 );
             });
             warlordsPlayer.getAbilitiesMatching(ChainHeal.class).forEach(chainHeal -> {

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Meteor.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Meteor.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.Fireball;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -42,7 +43,9 @@ public class Meteor implements SpecBoostManager.SpecBoost<Meteor> {
             warlordsPlayer.getAbilitiesMatching(Fireball.class).forEach(fireball ->
                     fireball.getDamageValues()
                             .getFireballDamage()
-                            .forEachValue(floatModifiable -> floatModifiable.addMultiplicativeModifierAdd("Spec Boost", damageIncrease / 100))
+                            .forEachValue(floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                                    "Spec Boost", damageIncrease / 100
+                            ))
             );
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MightyFists.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MightyFists.java
@@ -8,6 +8,7 @@ import com.ebicep.warlords.events.player.ingame.WarlordsPlayerWoundedEvent;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -63,7 +64,7 @@ public class MightyFists implements SpecBoostManager.SpecBoost<MightyFists> {
             this.warlordsEntity = warlordsPlayer;
 
             warlordsPlayer.getAbilitiesMatching(WoundingStrikeBerserker.class).forEach(woundingStrike -> {
-                woundingStrike.getWounding().addAdditiveModifier("Spec Boost", woundingIncreasePercent);
+                woundingStrike.getWounding().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", woundingIncreasePercent);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/PactOfProtection.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/PactOfProtection.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownManager;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.Collections;
@@ -58,7 +59,7 @@ public class PactOfProtection implements SpecBoostManager.SpecBoost<PactOfProtec
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(MysticalBarrier.class).forEach(mysticalBarrier -> {
-                mysticalBarrier.getCooldown().addMultiplicativeModifierAdd("Spec Boost", -mysticalBarrierCooldownReductionPercent / 100);
+                mysticalBarrier.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -mysticalBarrierCooldownReductionPercent / 100);
             });
         }
 
@@ -72,7 +73,10 @@ public class PactOfProtection implements SpecBoostManager.SpecBoost<PactOfProtec
                 return;
             }
             regularCooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (e, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToDivisionDecimal(targetDamageReductionPercent));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        getStringName(),
+                        AbstractAbility.convertToDivisionDecimal(targetDamageReductionPercent)
+                );
                     }
             );
             RegularCooldown<Boost> pactCooldown = new RegularCooldown<>(
@@ -90,7 +94,10 @@ public class PactOfProtection implements SpecBoostManager.SpecBoost<PactOfProtec
                     })
             );
             pactCooldown.addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (e, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToMultiplicationDecimal(selfDamageIncreasePercent));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        getStringName(),
+                        AbstractAbility.convertToMultiplicationDecimal(selfDamageIncreasePercent)
+                );
                     }
             );
             Consumer<CooldownManager> oldOnRemoveForce = regularCooldown.getOnRemoveForce();

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/PenitentResolve.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/PenitentResolve.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.Collections;
@@ -54,7 +55,7 @@ public class PenitentResolve implements SpecBoostManager.SpecBoost<PenitentResol
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
-            warlordsPlayer.getHealth().addAdditiveModifier("Spec Boost (Base)", healthIncrease);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost (Base)", healthIncrease);
         }
 
         @EventHandler

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/PermeatingLink.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/PermeatingLink.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PersistentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -65,7 +66,10 @@ public class PermeatingLink implements SpecBoostManager.SpecBoost<PermeatingLink
                     false
             ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                         if (event.getCause().isEmpty()) {
-                            currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToMultiplicationDecimal(meleeDamageIncreasePercent));
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                    getStringName(),
+                                    AbstractAbility.convertToMultiplicationDecimal(meleeDamageIncreasePercent)
+                            );
                             return;
                         }
                         if (event.getAbility() instanceof SpiritLink) {
@@ -73,7 +77,7 @@ public class PermeatingLink implements SpecBoostManager.SpecBoost<PermeatingLink
                                     .filterCooldownClassAndMapToObjectsOfClass(Soulbinding.SoulbindingData.class)
                                     .anyMatch(soulbindingData -> soulbindingData.hasBoundPlayer(event.getWarlordsEntity()));
                             if (boundPlayer) {
-                                currentDamageValue.addMultiplicativeModifierMult(getStringName(),
+                                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getStringName(),
                                         AbstractAbility.convertToMultiplicationDecimal(spiritLinkDamageToSoulboundIncreasePercent)
                                 );
                             }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Portal.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Portal.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.abilities.internal.AbstractAbility;
 import com.ebicep.warlords.abilities.internal.AbstractTimeWarp;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.TextComponent;
 
 import java.util.List;
@@ -49,7 +50,7 @@ public class Portal implements SpecBoostManager.SpecBoost<Portal> {
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(com.ebicep.warlords.abilities.Fireball.class).forEach(fireball -> {
-                fireball.getDamageValues().getFireballDamage().critChance().addAdditiveModifier("Spec Boost", fireballCritChanceIncrease);
+                fireball.getDamageValues().getFireballDamage().critChance().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", fireballCritChanceIncrease);
                 fireball.setMaxFullDistance(fireball.getMaxFullDistance() - fireballRangeDecreaseBlocks);
             });
             List<AbstractAbility> abilities = warlordsPlayer.getAbilities();

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/RadiantLight.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/RadiantLight.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.RayOfLight;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -41,7 +42,7 @@ public class RadiantLight implements SpecBoostManager.SpecBoost<RadiantLight> {
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(RayOfLight.class).forEach(rayOfLight -> {
                 rayOfLight.getHealValues().getRayHealing().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", rayOfLightHealingIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", rayOfLightHealingIncreasePercent / 100)
                 );
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/RallyingPresence.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/RallyingPresence.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.AbstractCooldown;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.player.ingame.motionsystem.MotionModifierBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -88,7 +89,10 @@ public class RallyingPresence implements SpecBoostManager.SpecBoost<RallyingPres
                 return;
             }
             regularCooldown.addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (e, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToDivisionDecimal(inspiringPresenceDamageReductionPercent));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        getStringName(),
+                        AbstractAbility.convertToDivisionDecimal(inspiringPresenceDamageReductionPercent)
+                );
                     }
             );
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/RecklessAscent.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/RecklessAscent.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 
@@ -63,7 +64,7 @@ public class RecklessAscent implements SpecBoostManager.SpecBoost<RecklessAscent
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(RecklessCharge.class).forEach(recklessCharge -> {
                 recklessCharge.setAdditionalBlocks(recklessCharge.getAdditionalBlocks() + travelDistanceIncrease);
-                recklessCharge.getHitBoxRadius().addAdditiveModifier("Spec Boost", radiusIncrease);
+                recklessCharge.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", radiusIncrease);
                 recklessCharge.setVerticalMovement(true);
             });
         }
@@ -107,7 +108,10 @@ public class RecklessAscent implements SpecBoostManager.SpecBoost<RecklessAscent
                         cooldownManager -> {},
                         damageReductionDurationTicks
                 ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (e, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToDivisionDecimal(damageReductionPercent));
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                            getStringName(),
+                            AbstractAbility.convertToDivisionDecimal(damageReductionPercent)
+                    );
                         }
                 ));
             }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/RiftAmbush.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/RiftAmbush.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.util.bukkit.LocationBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.event.EventHandler;
@@ -65,7 +66,7 @@ public class RiftAmbush implements SpecBoostManager.SpecBoost<RiftAmbush> {
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(SoulSwitch.class).forEach(soulSwitch -> {
-                soulSwitch.getHitBoxRadius().addAdditiveModifier("Spec Boost", soulSwitchRadiusIncrease);
+                soulSwitch.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", soulSwitchRadiusIncrease);
                 soulSwitch.setVerticalLimit(soulSwitchVerticalLimit);
                 soulSwitch.setDamageReduction(soulSwitch.getDamageReduction() + soulSwitchDamageReductionIncreasePercent);
                 soulSwitch.setCanSwitchToCarrier(true);

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/RuinousHex.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/RuinousHex.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.FortifyingHex;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -53,9 +54,9 @@ public class RuinousHex implements SpecBoostManager.SpecBoost<RuinousHex> {
             warlordsPlayer.getAbilitiesMatching(FortifyingHex.class).forEach(fortifyingHex -> {
                 fortifyingHex.setMaxEnemiesHit(fortifyingHex.getMaxEnemiesHit() + fortifyingHexEnemyPierceIncrease);
                 fortifyingHex.getDamageValues().getHexDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", fortifyingHexDamageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", fortifyingHexDamageIncreasePercent / 100)
                 );
-                fortifyingHex.getEnergyCost().addAdditiveModifier("Spec Boost", fortifyingHexEnergyCostIncrease);
+                fortifyingHex.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", fortifyingHexEnergyCostIncrease);
                 fortifyingHex.setMaxAlliesHit(fortifyingHex.getMaxAlliesHit() - fortifyingHexAllyPierceReduction);
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SanctionBurst.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SanctionBurst.java
@@ -1,6 +1,9 @@
 package com.ebicep.warlords.player.general.specboosts.boosts;
 
-import com.ebicep.warlords.abilities.*;
+import com.ebicep.warlords.abilities.HeartToHeart;
+import com.ebicep.warlords.abilities.PrismGuard;
+import com.ebicep.warlords.abilities.SoulShackle;
+import com.ebicep.warlords.abilities.Vindicate;
 import com.ebicep.warlords.events.player.ingame.WarlordsAbilityActivateEvent;
 import com.ebicep.warlords.events.player.ingame.WarlordsAddCooldownEvent;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
@@ -10,6 +13,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.AbstractCooldown;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownManager;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.util.Vector;
@@ -58,14 +62,17 @@ public class SanctionBurst implements SpecBoostManager.SpecBoost<SanctionBurst> 
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(HeartToHeart.class).forEach(heartToHeart -> {
-                heartToHeart.getHitBoxRadius().addAdditiveModifier("Spec Boost", heartToHeartRangeIncrease);
+                heartToHeart.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", heartToHeartRangeIncrease);
                 heartToHeart.setFlagDistance(heartToHeart.getFlagDistance() + heartToHeartFlagRangeIncrease);
                 heartToHeart.setTargetEnemies(true);
             });
             warlordsPlayer.getAbilitiesMatching(SoulShackle.class).forEach(soulShackle -> {
                 soulShackle.getDamageValues()
                            .getShackleDamage()
-                           .forEachValue(floatModifier -> floatModifier.addMultiplicativeModifierAdd("Spec Boost", -soulShackleDamageDecreasePercent / 100));
+                           .forEachValue(floatModifier -> floatModifier.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                                   "Spec Boost",
+                                   -soulShackleDamageDecreasePercent / 100
+                           ));
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SeismicShift.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SeismicShift.java
@@ -6,6 +6,7 @@ import com.ebicep.warlords.events.player.ingame.WarlordsDamageHealingFinalEvent;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -55,7 +56,7 @@ public class SeismicShift implements SpecBoostManager.SpecBoost<SeismicShift> {
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(SeismicWaveBerserker.class).forEach(seismicWave -> {
-                seismicWave.getCooldown().addAdditiveModifier("Spec Boost", -seismicWaveCooldownReductionTicks / 20f);
+                seismicWave.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -seismicWaveCooldownReductionTicks / 20f);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SharpFangs.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SharpFangs.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.PoisonousHex;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -41,10 +42,10 @@ public class SharpFangs implements SpecBoostManager.SpecBoost<SharpFangs> {
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(PoisonousHex.class).forEach(poisonousHex -> {
                 poisonousHex.getDamageValues().getHexDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", poisonousHexDamageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", poisonousHexDamageIncreasePercent / 100)
                 );
                 poisonousHex.getDamageValues().getHexDOTDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", poisonousHexDamageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", poisonousHexDamageIncreasePercent / 100)
                 );
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SoulRend.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SoulRend.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.FallenSouls;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -41,7 +42,7 @@ public class SoulRend implements SpecBoostManager.SpecBoost<SoulRend> {
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(FallenSouls.class).forEach(fallenSouls -> {
                 fallenSouls.getDamageValues().getFallenSoulDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", fallenSoulsDamageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", fallenSoulsDamageIncreasePercent / 100)
                 );
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SovereignSolitude.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SovereignSolitude.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.AbstractCooldown;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -64,7 +65,7 @@ public class SovereignSolitude implements SpecBoostManager.SpecBoost<SovereignSo
                 crusadersStrike.setBlockedByArcaneShield(false);
             });
             warlordsPlayer.getAbilitiesMatching(HolyRadianceCrusader.class).forEach(holyRadiance -> {
-                holyRadiance.getCooldown().addAdditiveModifier("Spec Boost", -radianceCooldownReductionTicks / 20f);
+                holyRadiance.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -radianceCooldownReductionTicks / 20f);
                 holyRadiance.setMarkSpeed(markedAllySpeedPercent);
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/StackulatorMax.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/StackulatorMax.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.abilities.PoisonousHex;
 import com.ebicep.warlords.abilities.SoulfireBeam;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -53,7 +54,7 @@ public class StackulatorMax implements SpecBoostManager.SpecBoost<StackulatorMax
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(PoisonousHex.class).forEach(poisonousHex -> {
                 poisonousHex.getDamageValues().getHexDOTDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addAdditiveModifier("Spec Boost", poisonousHexTickDamageIncrease)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", poisonousHexTickDamageIncrease)
                 );
                 poisonousHex.setTickDurationDot(poisonousHex.getTickDurationDot() - poisonousHex.getTicksBetweenDot());
             });

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SteadfastWarp.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SteadfastWarp.java
@@ -1,7 +1,7 @@
 package com.ebicep.warlords.player.general.specboosts.boosts;
 
-import com.ebicep.warlords.abilities.internal.AbstractArcaneShield;
 import com.ebicep.warlords.abilities.TimeWarpCryomancer;
+import com.ebicep.warlords.abilities.internal.AbstractArcaneShield;
 import com.ebicep.warlords.events.player.ingame.WarlordsAddCooldownEvent;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
@@ -9,6 +9,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.AbstractCooldown;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -57,7 +58,7 @@ public class SteadfastWarp implements SpecBoostManager.SpecBoost<SteadfastWarp> 
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
-            warlordsPlayer.getHealth().addAdditiveModifier("Spec Boost (Base)", healthIncrease);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost (Base)", healthIncrease);
             warlordsPlayer.getAbilitiesMatching(AbstractArcaneShield.class).forEach(arcaneShield -> {
                 arcaneShield.setShieldPercentage(arcaneShield.getShieldPercentage() - absorptionDecreasePercent);
             });

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Striker.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Striker.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.WoundingStrikeDefender;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -43,9 +44,9 @@ public class Striker implements SpecBoostManager.SpecBoost<Striker> {
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(WoundingStrikeDefender.class).forEach(woundingStrike -> {
                 woundingStrike.getDamageValues().getStrikeDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", woundingStrikeDamageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", woundingStrikeDamageIncreasePercent / 100)
                 );
-                woundingStrike.getWounding().addAdditiveModifier("Spec Boost", woundingIncreasePercent);
+                woundingStrike.getWounding().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", woundingIncreasePercent);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SustainedOnslaught.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SustainedOnslaught.java
@@ -7,6 +7,7 @@ import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -52,10 +53,10 @@ public class SustainedOnslaught implements SpecBoostManager.SpecBoost<SustainedO
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(ImpalingStrike.class).forEach(impalingStrike -> {
-                impalingStrike.getEnergyCost().addAdditiveModifier("Spec Boost", -impalingStrikeEnergyCostReduction);
+                impalingStrike.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -impalingStrikeEnergyCostReduction);
             });
             warlordsPlayer.getAbilitiesMatching(VitalityConcoction.class).forEach(vitalityConcoction -> {
-                vitalityConcoction.getCooldown().addAdditiveModifier("Spec Boost", -vitalityConcoctionCooldownReductionSeconds);
+                vitalityConcoction.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -vitalityConcoctionCooldownReductionSeconds);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SwiftJustice.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/SwiftJustice.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.*;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -60,7 +61,7 @@ public class SwiftJustice implements SpecBoostManager.SpecBoost<SwiftJustice> {
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(Vindicate.class).forEach(vindicate -> {
-                vindicate.getCooldown().addAdditiveModifier("Spec Boost", -vindicateCooldownReductionSeconds);
+                vindicate.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -vindicateCooldownReductionSeconds);
             });
         }
 
@@ -108,7 +109,7 @@ public class SwiftJustice implements SpecBoostManager.SpecBoost<SwiftJustice> {
                                                     .filter(regularCooldown -> !regularCooldown.getFlags().contains(CooldownFlag.CANNOT_BE_REDUCED) &&
                                                             !regularCooldown.getFlags().contains(CooldownFlag.CANNOT_BE_REDUCED_VIND))
                                                     .forEach(regularCooldown -> regularCooldown.subtractTime(nextStrikeCooldownReductionTicks));
-                                            currentDamageValue.addMultiplicativeModifierMult(getStringName(),
+                                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getStringName(),
                                                     AbstractAbility.convertToMultiplicationDecimal(nextStrikeDamageIncreasePercent)
                                             );
                                         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Syringe.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Syringe.java
@@ -6,6 +6,7 @@ import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.EnumSet;
@@ -55,12 +56,12 @@ public class Syringe implements SpecBoostManager.SpecBoost<Syringe> {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(WaterBolt.class).forEach(waterBolt -> {
                 waterBolt.getDamageValues().getBoltDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", -waterBoltStatsDecreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -waterBoltStatsDecreasePercent / 100)
                 );
                 waterBolt.getHealValues().getBoltHealing().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", -waterBoltStatsDecreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -waterBoltStatsDecreasePercent / 100)
                 );
-                waterBolt.getDirectHitMultiplier().addAdditiveModifier("Spec Boost", waterBoltDirectHitHealingIncreasePercent);
+                waterBolt.getDirectHitMultiplier().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", waterBoltDirectHitHealingIncreasePercent);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/TorrentialSoul.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/TorrentialSoul.java
@@ -55,9 +55,9 @@ public class TorrentialSoul implements SpecBoostManager.SpecBoost<TorrentialSoul
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
-            warlordsPlayer.getEnergy().addAdditiveModifier("Spec Boost", maxEnergyIncrease);
+            warlordsPlayer.getEnergy().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", maxEnergyIncrease);
             warlordsPlayer.getAbilitiesMatching(SoulSwitch.class).forEach(soulSwitch -> {
-                soulSwitch.getEnergyCost().addOverridingModifier("Spec Boost", 0);
+                soulSwitch.getEnergyCost().addModifier(FloatModifiable.ModifierType.OVERRIDING, "Spec Boost", 0);
             });
             warlordsPlayer.getAbilitiesMatching(OrderOfEviscerate.class).forEach(orderOfEviscerate -> {
                 orderOfEviscerate.setSpeedBuff(orderOfEviscerate.getSpeedBuff() + orderOfEviscerateSpeedIncreasePercent);
@@ -76,7 +76,7 @@ public class TorrentialSoul implements SpecBoostManager.SpecBoost<TorrentialSoul
             }
             FloatModifiable.FloatModifier modifier = warlordsEntity
                     .getEnergyPerSec()
-                    .addAdditiveModifier("Spec Boost", orderOfEviscerateEnergyPerSecond, regularCooldown.getStartingTicks());
+                    .addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", orderOfEviscerateEnergyPerSecond, regularCooldown.getStartingTicks());
             Consumer<CooldownManager> oldOnRemoveForce = cooldown.getOnRemoveForce();
             cooldown.setOnRemoveForce(cooldownManager -> {
                 oldOnRemoveForce.accept(cooldownManager);

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/TotemicBoon.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/TotemicBoon.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.AbstractCooldown;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownFlag;
 import com.ebicep.warlords.player.ingame.instances.type.CustomInstanceFlags;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.Comparator;
@@ -72,14 +73,17 @@ public class TotemicBoon implements SpecBoostManager.SpecBoost<TotemicBoon> {
             warlordsPlayer.getAbilitiesMatching(HealingTotem.class).forEach(healingTotem -> {
                 healingTotem.getHealValues()
                             .getTotemHealing()
-                            .forEachValue(floatModifiable -> floatModifiable.addMultiplicativeModifierAdd("Spec Boost", -healingTotemHealingDecreasePercent / 100f));
-                healingTotem.getEnergyCost().addMultiplicativeModifierAdd("Spec Boost", -healingTotemEnergyDecreasePercent / 100f);
-                healingTotem.getCooldown().addMultiplicativeModifierAdd("Spec Boost", -healingTotemCooldownDecreasePercent / 100f);
+                            .forEachValue(floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                                    "Spec Boost",
+                                    -healingTotemHealingDecreasePercent / 100f
+                            ));
+                healingTotem.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -healingTotemEnergyDecreasePercent / 100f);
+                healingTotem.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", -healingTotemCooldownDecreasePercent / 100f);
                 healingTotem.setMaxCharges(healingTotemMaxAbilityCharges);
                 healingTotem.setCurrentCharges(healingTotemMaxAbilityCharges);
                 healingTotem.setHealingPeriod((int) (healingTotem.getHealingPeriod() / healingTotemSpeedMultiplier));
                 healingTotem.setTickDuration((int) (healingTotem.getTickDuration() / healingTotemSpeedMultiplier));
-                healingTotem.getHitBoxRadius().addAdditiveModifier("Spec Boost", healingTotemRadiusIncrease);
+                healingTotem.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", healingTotemRadiusIncrease);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Transistor.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Transistor.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.LightningBolt;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -41,7 +42,7 @@ public class Transistor implements SpecBoostManager.SpecBoost<Transistor> {
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(LightningBolt.class).forEach(lightningBolt -> {
                 lightningBolt.getDamageValues().getBoltDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", lightningBoltDamageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", lightningBoltDamageIncreasePercent / 100)
                 );
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Trickster.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Trickster.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.player.ingame.WarlordsNPC;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.pve.mobs.pvp.TricksterDummy;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.citizensnpcs.trait.SkinTrait;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Location;
@@ -80,9 +81,9 @@ public class Trickster implements SpecBoostManager.SpecBoost<Trickster> {
             warlordsPlayer.getAbilitiesMatching(IncendiaryCurse.class).forEach(incendiaryCurse -> {
                 incendiaryCurse.setDamageIncreaseHealthThreshold(incendiaryCurse.getDamageIncreaseHealthThreshold() - incendiaryCurseDamageThresholdDecrease);
                 incendiaryCurse.getDamageValues().getCurseDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", incendiaryCurseDamageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", incendiaryCurseDamageIncreasePercent / 100)
                 );
-                incendiaryCurse.getEnergyCost().addAdditiveModifier("Spec Boost", incendiaryCurseEnergyCostIncrease);
+                incendiaryCurse.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", incendiaryCurseEnergyCostIncrease);
             });
             warlordsPlayer.getAbilitiesMatching(ShadowStep.class).forEach(shadowStep -> {
                 shadowStep.setLeapHealThreshold(shadowLeapHealthThreshold);

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/TyphoonBolt.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/TyphoonBolt.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.WaterBolt;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -41,7 +42,7 @@ public class TyphoonBolt implements SpecBoostManager.SpecBoost<TyphoonBolt> {
         public void apply(WarlordsPlayer warlordsPlayer) {
             warlordsPlayer.getAbilitiesMatching(WaterBolt.class).forEach(waterBolt -> {
                 waterBolt.getHealValues().getBoltHealing().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", waterBoltHealingIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", waterBoltHealingIncreasePercent / 100)
                 );
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/UndyingSteed.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/UndyingSteed.java
@@ -6,6 +6,7 @@ import com.ebicep.warlords.game.option.pvp.HorseOption;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -50,11 +51,11 @@ public class UndyingSteed implements SpecBoostManager.SpecBoost<UndyingSteed> {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(CripplingStrike.class).forEach(cripplingStrike -> {
                 cripplingStrike.getDamageValues().getStrikeDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", cripplingStrikeDamageIncreasePercent / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", cripplingStrikeDamageIncreasePercent / 100)
                 );
             });
             for (HorseOption horseOption : warlordsEntity.getGame().getOption(HorseOption.class)) {
-                horseOption.getHorseForPlayer(warlordsEntity).getHealth().addAdditiveModifier("Spec Boost", horseHealth);
+                horseOption.getHorseForPlayer(warlordsEntity).getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", horseHealth);
             }
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/UnmercifulHex.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/UnmercifulHex.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.abilities.MercifulHex;
 import com.ebicep.warlords.abilities.RayOfLight;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -44,7 +45,7 @@ public class UnmercifulHex implements SpecBoostManager.SpecBoost<UnmercifulHex> 
                 mercifulHex.setMaxEnemiesHit(Integer.MAX_VALUE);
                 mercifulHex.setHexStacksPerHitAfter(0);
                 mercifulHex.getDamageValues().getHexDamage().forEachValue(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierAdd("Spec Boost", mercifulHexDamageIncrease / 100)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Spec Boost", mercifulHexDamageIncrease / 100)
                 );
             });
             warlordsPlayer.getAbilitiesMatching(RayOfLight.class).forEach(rayOfLight -> {

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/VibrantOrbs.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/VibrantOrbs.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.OrbsOfLife;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -42,7 +43,9 @@ public class VibrantOrbs implements SpecBoostManager.SpecBoost<VibrantOrbs> {
             warlordsPlayer.getAbilitiesMatching(OrbsOfLife.class).forEach(orbsOfLife ->
                     orbsOfLife.getHealValues()
                             .getOrbHealing()
-                            .forEachValue(floatModifiable -> floatModifiable.addMultiplicativeModifierAdd("Spec Boost", healingIncreasePercent / 100))
+                              .forEachValue(floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                                      "Spec Boost", healingIncreasePercent / 100
+                              ))
             );
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/VigorousInfusion.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/VigorousInfusion.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.LightInfusionCrusader;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -46,11 +47,11 @@ public class VigorousInfusion implements SpecBoostManager.SpecBoost<VigorousInfu
 
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
-            warlordsPlayer.getEnergy().addAdditiveModifier("Spec Boost", maxEnergyIncrease);
+            warlordsPlayer.getEnergy().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", maxEnergyIncrease);
             warlordsPlayer.getAbilitiesMatching(LightInfusionCrusader.class).forEach(lightInfusion -> {
                 lightInfusion.setSpeedBuff(lightInfusion.getSpeedBuff() + infusionSpeedIncrease);
                 lightInfusion.setTickDuration(lightInfusion.getTickDuration() + infusionDurationIncreaseTicks);
-                lightInfusion.getCooldown().addAdditiveModifier("Spec Boost", -cooldownReductionSeconds);
+                lightInfusion.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -cooldownReductionSeconds);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/VitalPulse.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/VitalPulse.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 import com.ebicep.warlords.abilities.HeartToHeart;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -43,11 +44,11 @@ public class VitalPulse implements SpecBoostManager.SpecBoost<VitalPulse> {
 
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
-            warlordsPlayer.getHealth().addAdditiveModifier("Spec Boost (Base)", healthIncrease);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost (Base)", healthIncrease);
             warlordsPlayer.getAbilitiesMatching(HeartToHeart.class).forEach(heartToHeart -> {
-                heartToHeart.getCooldown().addAdditiveModifier("Spec Boost", -heartToHeartCooldownReductionSeconds);
+                heartToHeart.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -heartToHeartCooldownReductionSeconds);
                 heartToHeart.getHealValues().getHeartToHeartHealing().forEachValue(floatModifiable ->
-                        floatModifiable.addAdditiveModifier("Spec Boost", heartToHeartHealingIncrease)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", heartToHeartHealingIncrease)
                 );
             });
         }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/VitalityBoost.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/VitalityBoost.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.util.java.MathUtils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 
@@ -43,7 +44,7 @@ public class VitalityBoost implements SpecBoostManager.SpecBoost<VitalityBoost> 
 
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
-            warlordsPlayer.getHealth().addAdditiveModifier("Spec Boost (Base)", healthIncrease);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost (Base)", healthIncrease);
             warlordsPlayer.getCooldownManager().addCooldown(new PermanentCooldown<>(
                     getStringName(),
                     null,

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/WitheringPlague.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/WitheringPlague.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.AbstractCooldown;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownFilter;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
 import java.util.List;
@@ -74,7 +75,10 @@ public class WitheringPlague implements SpecBoostManager.SpecBoost<WitheringPlag
                         if (hexStacks < maxStacks) {
                             return;
                         }
-                        currentDamageValue.addMultiplicativeModifierMult(getStringName(), AbstractAbility.convertToMultiplicationDecimal(damageIncrease));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                        getStringName(),
+                        AbstractAbility.convertToMultiplicationDecimal(damageIncrease)
+                );
                     }
             );
         }

--- a/src/main/java/com/ebicep/warlords/player/ingame/cooldowns/cooldowns/custom/ItemAdditiveCooldown.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/cooldowns/cooldowns/custom/ItemAdditiveCooldown.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.items.types.AbstractItem;
 import com.ebicep.warlords.pve.mobs.Aspect;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -57,32 +58,32 @@ public class ItemAdditiveCooldown extends PermanentCooldown<AbstractItem> {
                 false
         );
         this.addModifier(Modifier.MODIFY_OUTGOING_HEALING, (event, currentHealValue) -> {
-                    currentHealValue.addMultiplicativeModifierMult(name, healMultiplier);
+            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, healMultiplier);
                 }
         );
         this.addModifier(Modifier.MODIFY_OUTGOING_CRIT_CHANCE, (event, currentCritChance) -> {
-                    currentCritChance.addAdditiveModifier(name, additionalCritChance);
+            currentCritChance.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, additionalCritChance);
                 }
         );
         this.addModifier(Modifier.MODIFY_OUTGOING_CRIT_MULTIPLIER, (event, currentCritMultiplier) -> {
-                    currentCritMultiplier.addAdditiveModifier(name, additionalCritMultiplier);
+            currentCritMultiplier.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, additionalCritMultiplier);
                 }
         );
         this.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (event.getWarlordsEntity() instanceof WarlordsNPC warlordsNPC) {
                         Aspect aspect = warlordsNPC.getMob().getAspect();
                         if (aspect == null) {
-                            currentDamageValue.addMultiplicativeModifierMult(name, damageMultiplier);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, damageMultiplier);
                             return;
                         }
                         AspectModifier aspectModifier = aspectModifiers.get(aspect);
                         if (aspectModifier == null) {
-                            currentDamageValue.addMultiplicativeModifierMult(name, damageMultiplier);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, damageMultiplier);
                             return;
                         }
-                        currentDamageValue.addMultiplicativeModifierMult(name, (damageMultiplier + aspectModifier.damageMultiplier - 1));
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, (damageMultiplier + aspectModifier.damageMultiplier - 1));
                     } else {
-                        currentDamageValue.addMultiplicativeModifierMult(name, damageMultiplier);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, damageMultiplier);
                     }
                 }
         );
@@ -96,7 +97,7 @@ public class ItemAdditiveCooldown extends PermanentCooldown<AbstractItem> {
                         if (aspectModifier == null) {
                             return;
                         }
-                        currentDamageValue.addMultiplicativeModifierMult(name, (aspectModifier.damageReductionMultiplier));
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, (aspectModifier.damageReductionMultiplier));
                     }
                 }
         );

--- a/src/main/java/com/ebicep/warlords/player/ingame/cooldowns/cooldowns/custom/SpawnDamageCooldown.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/cooldowns/cooldowns/custom/SpawnDamageCooldown.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class SpawnDamageCooldown extends RegularCooldown<SpawnDamageCooldown> {
 
@@ -22,7 +23,7 @@ public class SpawnDamageCooldown extends RegularCooldown<SpawnDamageCooldown> {
         );
         this.damageBoost = damageBoost;
         this.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addAdditiveModifier(name, damageBoost);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, damageBoost);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/player/ingame/instances/DamageInstanceProcessor.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/instances/DamageInstanceProcessor.java
@@ -147,6 +147,7 @@ public class DamageInstanceProcessor {
         }
 
         applyFlagMultiplier();
+        debugMessage.appendTitle("Modify Damage", NamedTextColor.AQUA);
         applyBeforeInterveneModifiers();
 
         if (handleIntervene()) {
@@ -407,8 +408,6 @@ public class DamageInstanceProcessor {
     }
 
     private void applyBeforeInterveneModifiers() {
-        debugMessage.appendTitle("Before Intervene", NamedTextColor.AQUA);
-
         if (trueDamage) {
             damageValue.addModifierListener(
                     InstanceFlags.TRUE_DAMAGE.createDisabledReason(),
@@ -423,7 +422,7 @@ public class DamageInstanceProcessor {
             togglePositiveBoosts(InstanceFlags.IGNORE_TARGET_DAMAGE_BOOST, true);
         }
         damageValue.addModifierListener(
-                InstanceManager.TARGET_LABEL,
+                InstanceManager.TARGET_LABEL_BI,
                 FloatModifiable.ModifierType.OVERRIDING,
                 FloatModifiable.ModifierType.ADDITIVE,
                 FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
@@ -433,7 +432,7 @@ public class DamageInstanceProcessor {
             abstractCooldown.applyModifiers(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, m -> m.apply(event, damageValue));
         }
         damageValue.removeModifierListener(
-                InstanceManager.TARGET_LABEL,
+                InstanceManager.TARGET_LABEL_BI,
                 FloatModifiable.ModifierType.OVERRIDING,
                 FloatModifiable.ModifierType.ADDITIVE,
                 FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
@@ -450,7 +449,7 @@ public class DamageInstanceProcessor {
             togglePositiveBoosts(InstanceFlags.IGNORE_SOURCE_DAMAGE_BOOST, true);
         }
         damageValue.addModifierListener(
-                InstanceManager.SOURCE_LABEL,
+                InstanceManager.SOURCE_LABEL_BI,
                 FloatModifiable.ModifierType.OVERRIDING,
                 FloatModifiable.ModifierType.ADDITIVE,
                 FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
@@ -460,7 +459,7 @@ public class DamageInstanceProcessor {
             abstractCooldown.applyModifiers(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, m -> m.apply(event, damageValue));
         }
         damageValue.removeModifierListener(
-                InstanceManager.SOURCE_LABEL,
+                InstanceManager.SOURCE_LABEL_BI,
                 FloatModifiable.ModifierType.OVERRIDING,
                 FloatModifiable.ModifierType.ADDITIVE,
                 FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
@@ -471,18 +470,6 @@ public class DamageInstanceProcessor {
         }
 
         damageValue.refresh();
-        if (damageHealValueBeforeAllReduction != damageValue.getCalculatedValue()) {
-            debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(1)
-                    .prefix(ComponentBuilder.create("Damage Value: ", NamedTextColor.LIGHT_PURPLE))
-                    .value(damageValue));
-        } else {
-            debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(1)
-                    .prefix(ComponentBuilder.create("Damage Value: ", NamedTextColor.LIGHT_PURPLE))
-                    .value(ComponentBuilder.create("No Change", NamedTextColor.WHITE)));
-        }
-
         damageHealValueBeforeInterveneReduction = damageValue.getCalculatedValue();
     }
 
@@ -592,97 +579,70 @@ public class DamageInstanceProcessor {
         playInterveneEffects(intervenedBy, calculatedDamageValue);
     }
 
-    private void applyFinalDamage() {
-        debugMessage.appendTitle("Modify Damage After All", NamedTextColor.AQUA);
-
+    private void applyAfterInterveneModifiers() {
+        if (trueDamage) {
+            damageValue.addModifierListener(
+                    InstanceFlags.TRUE_DAMAGE.createDisabledReason(),
+                    FloatModifiable.ModifierType.ADDITIVE, FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE
+            );
+        }
+        // target / self modifiers
+        if (ignoreDamageReduction) {
+            toggleNegativeBoosts(pierceDamage ? InstanceFlags.PIERCE : InstanceFlags.IGNORE_DAMAGE_REDUCTION_ONLY, true);
+        }
+        if (noTargetDamageBoost) {
+            togglePositiveBoosts(InstanceFlags.IGNORE_TARGET_DAMAGE_BOOST, true);
+        }
+        damageValue.addModifierListener(
+                InstanceManager.TARGET_LABEL_AI,
+                FloatModifiable.ModifierType.OVERRIDING,
+                FloatModifiable.ModifierType.ADDITIVE,
+                FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE
+        );
         for (AbstractCooldown<?> abstractCooldown : targetCooldownsDistinct) {
-            abstractCooldown.applyModifiers(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_ALL_MODIFIERS, m -> m.apply(event, damageValue, isCrit));
+            abstractCooldown.applyModifiers(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, m -> m.apply(event, damageValue));
+        }
+        damageValue.removeModifierListener(
+                InstanceManager.TARGET_LABEL_AI,
+                FloatModifiable.ModifierType.OVERRIDING,
+                FloatModifiable.ModifierType.ADDITIVE,
+                FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE
+        );
+        if (ignoreDamageReduction) {
+            toggleNegativeBoosts(pierceDamage ? InstanceFlags.PIERCE : InstanceFlags.IGNORE_DAMAGE_REDUCTION_ONLY, false);
+        }
+        if (noTargetDamageBoost) {
+            togglePositiveBoosts(InstanceFlags.IGNORE_TARGET_DAMAGE_BOOST, false);
+        }
+        // source / attacker modifiers
+        if (noSourceDamageBoost) {
+            togglePositiveBoosts(InstanceFlags.IGNORE_SOURCE_DAMAGE_BOOST, true);
+        }
+        damageValue.addModifierListener(
+                InstanceManager.SOURCE_LABEL_AI,
+                FloatModifiable.ModifierType.OVERRIDING,
+                FloatModifiable.ModifierType.ADDITIVE,
+                FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE
+        );
+        for (AbstractCooldown<?> abstractCooldown : sourceCooldownsDistinct) {
+            abstractCooldown.applyModifiers(Modifier.MODIFY_OUTGOING_DAMAGE_AFTER_INTERVENE, m -> m.apply(event, damageValue));
+        }
+        damageValue.removeModifierListener(
+                InstanceManager.SOURCE_LABEL,
+                FloatModifiable.ModifierType.OVERRIDING,
+                FloatModifiable.ModifierType.ADDITIVE,
+                FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE
+        );
+        if (noSourceDamageBoost) {
+            togglePositiveBoosts(InstanceFlags.IGNORE_SOURCE_DAMAGE_BOOST, false);
         }
 
         damageValue.refresh();
-        if (damageHealValueBeforeShieldReduction != damageValue.getCalculatedValue()) {
-            debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(1)
-                    .prefix(ComponentBuilder.create("Damage Value: ", NamedTextColor.LIGHT_PURPLE))
-                    .value(damageValue));
-        } else {
-            debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(1)
-                    .prefix(ComponentBuilder.create("Damage Value: ", NamedTextColor.LIGHT_PURPLE))
-                    .value(ComponentBuilder.create("No Change", NamedTextColor.WHITE)));
-        }
-
-        damageValue.callGlobalContributionCallbacks();
-
-        boolean debt = warlordsEntity.getCooldownManager().hasCooldownFromName("Spirits' Respite");
-        debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                .create(1)
-                .prefix(ComponentBuilder.create("Debt: ", NamedTextColor.LIGHT_PURPLE))
-                .value(ComponentBuilder.create("" + debt, NamedTextColor.GOLD))
-        );
-        warlordsEntity.getHitBy().put(source, 10);
-        warlordsEntity.cancelHealingPowerUp();
-
-        float finalDamageValue = damageValue.getCalculatedValue();
-        debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                .create(1)
-                .prefix(ComponentBuilder.create("Final Damage Value: ", NamedTextColor.LIGHT_PURPLE))
-                .value(ComponentBuilder.create(NumberFormat.formatOptionalHundredths(finalDamageValue), NamedTextColor.GOLD))
-        );
-
-        updateAbilityPools(finalDamageValue);
-
-        applyOnDamageModifiers(finalDamageValue);
-
-        float cappedDamage = Math.min(finalDamageValue,
-                warlordsEntity.getCurrentHealth() - (flags.contains(InstanceFlags.CANT_KILL) ? 1 : 0)
-        );
-        debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                .create(1)
-                .prefix(ComponentBuilder.create("Capped Damage Value: ", NamedTextColor.LIGHT_PURPLE))
-                .value(ComponentBuilder.create(NumberFormat.formatOptionalHundredths(cappedDamage), NamedTextColor.GOLD))
-        );
-
-        if (!flags.contains(InstanceFlags.NO_MESSAGE)) {
-            sendDamageMessage(finalDamageValue);
-        }
-
-        source.addDamage(cappedDamage, FlagHolder.isPlayerHolderFlag(warlordsEntity));
-        warlordsEntity.addDamageTaken(cappedDamage);
-        warlordsEntity.playHurtAnimation(source);
-        warlordsEntity.resetRegenTimer();
-        warlordsEntity.updateHealth();
-
-        if (source.isNoEnergyConsumption()) {
-            source.getRecordDamage().add(cappedDamage);
-        }
-
-        float newHealth = calculateNewHealth(debt, finalDamageValue);
-        debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                .create(1)
-                .prefix(ComponentBuilder.create("New Health: ", NamedTextColor.LIGHT_PURPLE))
-                .value(ComponentBuilder.create(NumberFormat.formatOptionalHundredths(newHealth), NamedTextColor.GOLD))
-        );
-        warlordsEntity.setCurrentHealth(newHealth);
-
-        if (newHealth <= 0) {
-            handleDeath(finalDamageValue);
-        } else {
-            if (!flags.contains(InstanceFlags.NO_HIT_SOUND) && warlordsEntity != source && finalDamageValue != 0) {
-                warlordsEntity.playHitSound(source);
-            }
-        }
-
-        finalEvent = new WarlordsDamageHealingFinalEvent(
-                event, flags, warlordsEntity, source, ability, cause,
-                initialHealth, damageHealValueBeforeAllReduction,
-                damageHealValueBeforeInterveneReduction, damageHealValueBeforeShieldReduction,
-                finalDamageValue, calculatedCritChance, calculatedCritMultiplier,
-                isCrit, true, WarlordsDamageHealingFinalEvent.FinalEventFlag.REGULAR
-        );
-
-        warlordsEntity.getSecondStats().addDamageHealingEventAsSelf(finalEvent);
-        source.getSecondStats().addDamageHealingEventAsAttacker(finalEvent);
+        damageHealValueBeforeShieldReduction = damageValue.getCalculatedValue();
     }
 
     private void handleInterveneBreak(
@@ -920,84 +880,103 @@ public class DamageInstanceProcessor {
         }
     }
 
-    private void applyAfterInterveneModifiers() {
-        debugMessage.appendTitle("After Intervene", NamedTextColor.AQUA);
-
-        if (trueDamage) {
-            damageValue.addModifierListener(
-                    InstanceFlags.TRUE_DAMAGE.createDisabledReason(),
-                    FloatModifiable.ModifierType.ADDITIVE, FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE
-            );
-        }
-        // target / self modifiers
-        if (ignoreDamageReduction) {
-            toggleNegativeBoosts(pierceDamage ? InstanceFlags.PIERCE : InstanceFlags.IGNORE_DAMAGE_REDUCTION_ONLY, true);
-        }
-        if (noTargetDamageBoost) {
-            togglePositiveBoosts(InstanceFlags.IGNORE_TARGET_DAMAGE_BOOST, true);
-        }
+    private void applyFinalDamage() {
         damageValue.addModifierListener(
-                InstanceManager.TARGET_LABEL,
+                InstanceManager.TARGET_LABEL_AA,
                 FloatModifiable.ModifierType.OVERRIDING,
                 FloatModifiable.ModifierType.ADDITIVE,
                 FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
                 FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE
         );
         for (AbstractCooldown<?> abstractCooldown : targetCooldownsDistinct) {
-            abstractCooldown.applyModifiers(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, m -> m.apply(event, damageValue));
+            abstractCooldown.applyModifiers(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_ALL_MODIFIERS, m -> m.apply(event, damageValue, isCrit));
         }
         damageValue.removeModifierListener(
-                InstanceManager.TARGET_LABEL,
+                InstanceManager.TARGET_LABEL_AA,
                 FloatModifiable.ModifierType.OVERRIDING,
                 FloatModifiable.ModifierType.ADDITIVE,
                 FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
                 FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE
         );
-        if (ignoreDamageReduction) {
-            toggleNegativeBoosts(pierceDamage ? InstanceFlags.PIERCE : InstanceFlags.IGNORE_DAMAGE_REDUCTION_ONLY, false);
-        }
-        if (noTargetDamageBoost) {
-            togglePositiveBoosts(InstanceFlags.IGNORE_TARGET_DAMAGE_BOOST, false);
-        }
-        // source / attacker modifiers
-        if (noSourceDamageBoost) {
-            togglePositiveBoosts(InstanceFlags.IGNORE_SOURCE_DAMAGE_BOOST, true);
-        }
-        damageValue.addModifierListener(
-                InstanceManager.SOURCE_LABEL,
-                FloatModifiable.ModifierType.OVERRIDING,
-                FloatModifiable.ModifierType.ADDITIVE,
-                FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
-                FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE
-        );
-        for (AbstractCooldown<?> abstractCooldown : sourceCooldownsDistinct) {
-            abstractCooldown.applyModifiers(Modifier.MODIFY_OUTGOING_DAMAGE_AFTER_INTERVENE, m -> m.apply(event, damageValue));
-        }
-        damageValue.removeModifierListener(
-                InstanceManager.SOURCE_LABEL,
-                FloatModifiable.ModifierType.OVERRIDING,
-                FloatModifiable.ModifierType.ADDITIVE,
-                FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
-                FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE
-        );
-        if (noSourceDamageBoost) {
-            togglePositiveBoosts(InstanceFlags.IGNORE_SOURCE_DAMAGE_BOOST, false);
-        }
 
         damageValue.refresh();
-        if (damageHealValueBeforeInterveneReduction != damageValue.getCalculatedValue()) {
-            debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(1)
-                    .prefix(ComponentBuilder.create("Damage Value: ", NamedTextColor.LIGHT_PURPLE))
-                    .value(damageValue));
-        } else {
-            debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(1)
-                    .prefix(ComponentBuilder.create("Damage Value: ", NamedTextColor.LIGHT_PURPLE))
-                    .value(ComponentBuilder.create("No Change", NamedTextColor.WHITE)));
+        debugMessage.append(InstanceDebugHoverable.LevelBuilder
+                .create(1)
+                .prefix(ComponentBuilder.create("Damage Value: ", NamedTextColor.LIGHT_PURPLE))
+                .value(damageValue));
+        debugMessage.appendTitle("Final", NamedTextColor.AQUA);
+
+        damageValue.callGlobalContributionCallbacks();
+
+        boolean debt = warlordsEntity.getCooldownManager().hasCooldownFromName("Spirits' Respite");
+        debugMessage.append(InstanceDebugHoverable.LevelBuilder
+                .create(1)
+                .prefix(ComponentBuilder.create("Debt: ", NamedTextColor.LIGHT_PURPLE))
+                .value(ComponentBuilder.create("" + debt, NamedTextColor.GOLD))
+        );
+        warlordsEntity.getHitBy().put(source, 10);
+        warlordsEntity.cancelHealingPowerUp();
+
+        float finalDamageValue = damageValue.getCalculatedValue();
+        debugMessage.append(InstanceDebugHoverable.LevelBuilder
+                .create(1)
+                .prefix(ComponentBuilder.create("Final Damage Value: ", NamedTextColor.LIGHT_PURPLE))
+                .value(ComponentBuilder.create(NumberFormat.formatOptionalHundredths(finalDamageValue), NamedTextColor.GOLD))
+        );
+
+        updateAbilityPools(finalDamageValue);
+
+        applyOnDamageModifiers(finalDamageValue);
+
+        float cappedDamage = Math.min(finalDamageValue,
+                warlordsEntity.getCurrentHealth() - (flags.contains(InstanceFlags.CANT_KILL) ? 1 : 0)
+        );
+        debugMessage.append(InstanceDebugHoverable.LevelBuilder
+                .create(1)
+                .prefix(ComponentBuilder.create("Capped Damage Value: ", NamedTextColor.LIGHT_PURPLE))
+                .value(ComponentBuilder.create(NumberFormat.formatOptionalHundredths(cappedDamage), NamedTextColor.GOLD))
+        );
+
+        if (!flags.contains(InstanceFlags.NO_MESSAGE)) {
+            sendDamageMessage(finalDamageValue);
         }
 
-        damageHealValueBeforeShieldReduction = damageValue.getCalculatedValue();
+        source.addDamage(cappedDamage, FlagHolder.isPlayerHolderFlag(warlordsEntity));
+        warlordsEntity.addDamageTaken(cappedDamage);
+        warlordsEntity.playHurtAnimation(source);
+        warlordsEntity.resetRegenTimer();
+        warlordsEntity.updateHealth();
+
+        if (source.isNoEnergyConsumption()) {
+            source.getRecordDamage().add(cappedDamage);
+        }
+
+        float newHealth = calculateNewHealth(debt, finalDamageValue);
+        debugMessage.append(InstanceDebugHoverable.LevelBuilder
+                .create(1)
+                .prefix(ComponentBuilder.create("New Health: ", NamedTextColor.LIGHT_PURPLE))
+                .value(ComponentBuilder.create(NumberFormat.formatOptionalHundredths(newHealth), NamedTextColor.GOLD))
+        );
+        warlordsEntity.setCurrentHealth(newHealth);
+
+        if (newHealth <= 0) {
+            handleDeath(finalDamageValue);
+        } else {
+            if (!flags.contains(InstanceFlags.NO_HIT_SOUND) && warlordsEntity != source && finalDamageValue != 0) {
+                warlordsEntity.playHitSound(source);
+            }
+        }
+
+        finalEvent = new WarlordsDamageHealingFinalEvent(
+                event, flags, warlordsEntity, source, ability, cause,
+                initialHealth, damageHealValueBeforeAllReduction,
+                damageHealValueBeforeInterveneReduction, damageHealValueBeforeShieldReduction,
+                finalDamageValue, calculatedCritChance, calculatedCritMultiplier,
+                isCrit, true, WarlordsDamageHealingFinalEvent.FinalEventFlag.REGULAR
+        );
+
+        warlordsEntity.getSecondStats().addDamageHealingEventAsSelf(finalEvent);
+        source.getSecondStats().addDamageHealingEventAsAttacker(finalEvent);
     }
 
     private void handleActiveShield(Shield shield, RegularCooldown<Shield> cooldown) {

--- a/src/main/java/com/ebicep/warlords/player/ingame/instances/DamageInstanceProcessor.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/instances/DamageInstanceProcessor.java
@@ -28,6 +28,7 @@ import com.ebicep.warlords.util.java.NumberFormat;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
 import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.MultiFloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEvent;
@@ -65,7 +66,7 @@ public class DamageInstanceProcessor {
     private final FloatModifiable max;
     private final FloatModifiable critChance;
     private final FloatModifiable critMultiplier;
-    private final FloatModifiable damageValue;
+    private final MultiFloatModifiable damageValue;
     // Flags
     private final boolean isMeleeHit;
     private final boolean isFallDamage;
@@ -118,7 +119,9 @@ public class DamageInstanceProcessor {
         this.targetCooldownsDistinct = warlordsEntity.getCooldownManager().getCooldownsDistinct();
         this.sourceCooldownsDistinct = source.getCooldownManager().getCooldownsDistinct();
         this.finalEvent = null;
-        this.damageValue = new FloatModifiable(ThreadLocalRandom.current().nextFloat() * (max.getCalculatedValue() - min.getCalculatedValue()) + min.getCalculatedValue());
+        this.damageValue = new MultiFloatModifiable(
+                new FloatModifiable(ThreadLocalRandom.current().nextFloat() * (max.getCalculatedValue() - min.getCalculatedValue()) + min.getCalculatedValue())
+        );
     }
 
     private void applyPreEventModifiers() {
@@ -261,7 +264,7 @@ public class DamageInstanceProcessor {
         isCrit = calculatedCritChance > 0 && crit <= calculatedCritChance && source.isCanCrit();
 
         if (isCrit) {
-            damageValue.addMultiplicativeModifierAdd("Crit Multiplier", calculatedCritMultiplier / 100f - 1);
+            damageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Crit Multiplier", calculatedCritMultiplier / 100f - 1);
         }
 
         damageHealValueBeforeAllReduction = damageValue.getCalculatedValue();
@@ -291,7 +294,9 @@ public class DamageInstanceProcessor {
     }
 
     private void applySpecDamageResistance() {
-        FloatModifiable.FloatModifier modifier = damageValue.addMultiplicativeModifierMult("Spec Damage Resistance", 1 - warlordsEntity.getSpec().getDamageResistance() / 100f);
+        FloatModifiable.FloatModifier modifier = damageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                "Spec Damage Resistance", 1 - warlordsEntity.getSpec().getDamageResistance() / 100f
+        );
         if (flags.contains(InstanceFlags.IGNORE_SELF_RES)) {
             modifier.addDisabledReason(InstanceFlags.IGNORE_SELF_RES.name());
         }
@@ -384,7 +389,10 @@ public class DamageInstanceProcessor {
         if (flagMultiplier == 1) {
             return;
         }
-        FloatModifiable.FloatModifier modifier = damageValue.addMultiplicativeModifierMult("Flag Carrier Multiplier", (float) flagMultiplier);
+        FloatModifiable.FloatModifier modifier = damageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                "Flag Carrier Multiplier",
+                (float) flagMultiplier
+        );
         if (trueDamage) {
             modifier.addDisabledReason(InstanceFlags.TRUE_DAMAGE.name());
         }
@@ -573,7 +581,7 @@ public class DamageInstanceProcessor {
         float maxDamagePrevented = data.getMaxDamagePrevented();
         float preDamagePrevented = data.getDamagePrevented();
 
-        damageValue.callContributionCallbacks();
+        damageValue.callGlobalContributionCallbacks();
 
         if (preDamagePrevented + calculatedDamageValue > maxDamagePrevented) {
             handleInterveneBreak(interveneCooldown, data, intervenedBy, calculatedDamageValue, maxDamagePrevented, preDamagePrevented);
@@ -604,7 +612,7 @@ public class DamageInstanceProcessor {
                     .value(ComponentBuilder.create("No Change", NamedTextColor.WHITE)));
         }
 
-        damageValue.callContributionCallbacks();
+        damageValue.callGlobalContributionCallbacks();
 
         boolean debt = warlordsEntity.getCooldownManager().hasCooldownFromName("Spirits' Respite");
         debugMessage.append(InstanceDebugHoverable.LevelBuilder
@@ -792,7 +800,7 @@ public class DamageInstanceProcessor {
             cooldown.setTicksLeft(0);
         }
 
-        damageValue.callContributionCallbacks();
+        damageValue.callGlobalContributionCallbacks();
 
         if (shield.isBroken()) {
             handleBrokenShield(shield, cooldown, preShieldHealth);

--- a/src/main/java/com/ebicep/warlords/player/ingame/instances/DamageInstanceProcessor.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/instances/DamageInstanceProcessor.java
@@ -147,7 +147,7 @@ public class DamageInstanceProcessor {
         }
 
         applyFlagMultiplier();
-        debugMessage.appendTitle("Modify Damage", NamedTextColor.AQUA);
+        debugMessage.appendTitle("Modified Damage", NamedTextColor.AQUA);
         applyBeforeInterveneModifiers();
 
         if (handleIntervene()) {
@@ -177,25 +177,30 @@ public class DamageInstanceProcessor {
 
     private void applyBeforeReductionModifiers() {
         debugMessage.appendTitle("Before Reduction", NamedTextColor.AQUA);
-        debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                .create(1)
-                .prefix(ComponentBuilder.create("Target Cooldowns", NamedTextColor.DARK_GREEN)));
 
-        for (AbstractCooldown<?> abstractCooldown : targetCooldownsDistinct) {
+        if (!targetCooldownsDistinct.isEmpty()) {
             debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(2)
-                    .prefix(abstractCooldown));
+                    .create(1)
+                    .prefix(ComponentBuilder.create("Target Cooldowns", NamedTextColor.DARK_GREEN)));
+
+            for (AbstractCooldown<?> abstractCooldown : targetCooldownsDistinct) {
+                debugMessage.append(InstanceDebugHoverable.LevelBuilder
+                        .create(2)
+                        .prefix(abstractCooldown));
+            }
         }
 
-        debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                .create(1)
-                .prefix(ComponentBuilder.create("Source Cooldowns", NamedTextColor.DARK_GREEN)));
-
-        for (AbstractCooldown<?> abstractCooldown : sourceCooldownsDistinct) {
-            abstractCooldown.applyModifiers(Modifier.DAMAGE_BEFORE_ANY_REDUCTION_ATTACKER, m -> m.apply(event));
+        if (!sourceCooldownsDistinct.isEmpty()) {
             debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(2)
-                    .prefix(abstractCooldown));
+                    .create(1)
+                    .prefix(ComponentBuilder.create("Source Cooldowns", NamedTextColor.DARK_RED)));
+
+            for (AbstractCooldown<?> abstractCooldown : sourceCooldownsDistinct) {
+                abstractCooldown.applyModifiers(Modifier.DAMAGE_BEFORE_ANY_REDUCTION_ATTACKER, m -> m.apply(event));
+                debugMessage.append(InstanceDebugHoverable.LevelBuilder
+                        .create(2)
+                        .prefix(abstractCooldown));
+            }
         }
     }
 
@@ -237,22 +242,12 @@ public class DamageInstanceProcessor {
                     .create(1)
                     .prefix(ComponentBuilder.create("Crit Chance: ", NamedTextColor.LIGHT_PURPLE))
                     .value(critChance));
-        } else {
-            debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(1)
-                    .prefix(ComponentBuilder.create("Crit Chance: ", NamedTextColor.LIGHT_PURPLE))
-                    .value(ComponentBuilder.create("No Change", NamedTextColor.WHITE)));
         }
         if (previousCritMultiplier != critMultiplier.getCalculatedValue()) {
             debugMessage.append(InstanceDebugHoverable.LevelBuilder
                     .create(1)
                     .prefix(ComponentBuilder.create("Crit Multiplier: ", NamedTextColor.LIGHT_PURPLE))
                     .value(critMultiplier));
-        } else {
-            debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(1)
-                    .prefix(ComponentBuilder.create("Crit Multiplier: ", NamedTextColor.LIGHT_PURPLE))
-                    .value(ComponentBuilder.create("No Change", NamedTextColor.WHITE)));
         }
 
         applyCriticalHit();
@@ -1016,34 +1011,11 @@ public class DamageInstanceProcessor {
     }
 
     private void applyShieldModifiers() {
-        debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                .create(1)
-                .prefix(ComponentBuilder.create("On Shield", NamedTextColor.DARK_GREEN))
-        );
-        debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                .create(2)
-                .prefix(ComponentBuilder.create("Target Cooldowns", NamedTextColor.DARK_GREEN))
-        );
-
         for (AbstractCooldown<?> abstractCooldown : targetCooldownsDistinct) {
             abstractCooldown.applyModifiers(Modifier.ON_INCOMING_SHIELD_DAMAGE, m -> m.apply(event, damageHealValueBeforeShieldReduction, isCrit));
-            debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(3)
-                    .prefix(abstractCooldown)
-            );
         }
-
-        debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                .create(2)
-                .prefix(ComponentBuilder.create("Attackers Cooldowns", NamedTextColor.DARK_GREEN))
-        );
-
         for (AbstractCooldown<?> abstractCooldown : sourceCooldownsDistinct) {
             abstractCooldown.applyModifiers(Modifier.ON_OUTGOING_SHIELD_DAMAGE, m -> m.apply(event, damageHealValueBeforeShieldReduction, isCrit));
-            debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(3)
-                    .prefix(abstractCooldown)
-            );
         }
     }
 

--- a/src/main/java/com/ebicep/warlords/player/ingame/instances/HealingInstanceProcessor.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/instances/HealingInstanceProcessor.java
@@ -403,45 +403,58 @@ public class HealingInstanceProcessor {
 
     private void applyBeforeReductionModifiers() {
         debugMessage.appendTitle("Before Reduction", NamedTextColor.AQUA);
-        debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                .create(1)
-                .prefix(ComponentBuilder.create("Target Cooldowns", NamedTextColor.DARK_GREEN)));
 
-        for (AbstractCooldown<?> abstractCooldown : targetCooldownsDistinct) {
+        if (!targetCooldownsDistinct.isEmpty()) {
             debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(2)
-                    .prefix(abstractCooldown));
+                    .create(1)
+                    .prefix(ComponentBuilder.create("Target Cooldowns", NamedTextColor.DARK_GREEN)));
+            for (AbstractCooldown<?> abstractCooldown : targetCooldownsDistinct) {
+                debugMessage.append(InstanceDebugHoverable.LevelBuilder
+                        .create(2)
+                        .prefix(abstractCooldown));
+            }
         }
 
-        debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                .create(1)
-                .prefix(ComponentBuilder.create("Source Cooldowns", NamedTextColor.DARK_GREEN)));
-
-        for (AbstractCooldown<?> abstractCooldown : sourceCooldownsDistinct) {
+        if (!sourceCooldownsDistinct.isEmpty()) {
             debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                    .create(2)
-                    .prefix(abstractCooldown));
+                    .create(1)
+                    .prefix(ComponentBuilder.create("Source Cooldowns", NamedTextColor.DARK_GREEN)));
+
+            for (AbstractCooldown<?> abstractCooldown : sourceCooldownsDistinct) {
+                debugMessage.append(InstanceDebugHoverable.LevelBuilder
+                        .create(2)
+                        .prefix(abstractCooldown));
+            }
         }
     }
 
     private void calculateCriticals() {
+        debugMessage.appendTitle("Crit Modifiers", NamedTextColor.AQUA);
+
+        float previousCritChance = critChance.getCalculatedValue();
+        float previousCritMultiplier = critMultiplier.getCalculatedValue();
+
         critChance.refresh();
         critMultiplier.refresh();
 
-        debugMessage.append(InstanceDebugHoverable.LevelBuilder
-                .create(1)
-                .prefix(ComponentBuilder.create("Crit Chance: ", NamedTextColor.LIGHT_PURPLE))
-                .value(critChance));
+        if (previousCritChance != critChance.getCalculatedValue()) {
+            debugMessage.append(InstanceDebugHoverable.LevelBuilder
+                    .create(1)
+                    .prefix(ComponentBuilder.create("Crit Chance: ", NamedTextColor.LIGHT_PURPLE))
+                    .value(critChance));
+        }
+        if (previousCritMultiplier != critMultiplier.getCalculatedValue()) {
         debugMessage.append(InstanceDebugHoverable.LevelBuilder
                 .create(1)
                 .prefix(ComponentBuilder.create("Crit Multiplier: ", NamedTextColor.LIGHT_PURPLE))
                 .value(critMultiplier));
+        }
 
         applyCriticalHit();
     }
 
     private void applyHealingModifiers() {
-        debugMessage.appendTitle("Before Heal", NamedTextColor.AQUA);
+        debugMessage.appendTitle("Modified Healing", NamedTextColor.AQUA);
 
         if (trueHealing) {
             healValue.addModifierListener(

--- a/src/main/java/com/ebicep/warlords/player/ingame/instances/HealingInstanceProcessor.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/instances/HealingInstanceProcessor.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.bukkit.ComponentBuilder;
 import com.ebicep.warlords.util.java.NumberFormat;
 import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.MultiFloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEvent;
@@ -47,7 +48,7 @@ public class HealingInstanceProcessor {
     private final FloatModifiable max;
     private final FloatModifiable critChance;
     private final FloatModifiable critMultiplier;
-    private final FloatModifiable healValue;
+    private final MultiFloatModifiable healValue;
     // Flags
     private final EnumSet<InstanceFlags> flags;
     private final boolean isLastStandFromShield;
@@ -87,7 +88,9 @@ public class HealingInstanceProcessor {
         this.targetCooldownsDistinct = warlordsEntity.getCooldownManager().getCooldownsDistinct();
         this.sourceCooldownsDistinct = source.getCooldownManager().getCooldownsDistinct();
         this.finalEvent = null;
-        this.healValue = new FloatModifiable(ThreadLocalRandom.current().nextFloat() * (max.getCalculatedValue() - min.getCalculatedValue()) + min.getCalculatedValue());
+        this.healValue = new MultiFloatModifiable(
+                new FloatModifiable(ThreadLocalRandom.current().nextFloat() * (max.getCalculatedValue() - min.getCalculatedValue()) + min.getCalculatedValue())
+        );
     }
 
     private void applyPreEventModifiers() {
@@ -130,7 +133,7 @@ public class HealingInstanceProcessor {
     }
 
     private void applyFinalHealing(float cappedHealValue) {
-        healValue.callContributionCallbacks();
+        healValue.callGlobalContributionCallbacks();
 
         applyOnHealModifiers(cappedHealValue);
 
@@ -504,7 +507,7 @@ public class HealingInstanceProcessor {
         isCrit = calculatedCritChance > 0 && crit <= calculatedCritChance && source.isCanCrit();
 
         if (isCrit) {
-            healValue.addMultiplicativeModifierMult("Crit Multiplier", calculatedCritMultiplier / 100f);
+            healValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Crit Multiplier", calculatedCritMultiplier / 100f);
         }
 
         healValueBeforeReduction = healValue.getCalculatedValue();

--- a/src/main/java/com/ebicep/warlords/player/ingame/instances/InstanceDebugHoverable.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/instances/InstanceDebugHoverable.java
@@ -5,11 +5,14 @@ import com.ebicep.warlords.player.ingame.cooldowns.AbstractCooldown;
 import com.ebicep.warlords.util.bukkit.ComponentBuilder;
 import com.ebicep.warlords.util.java.NumberFormat;
 import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.MultiFloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 public class InstanceDebugHoverable {
 
@@ -73,17 +76,17 @@ public class InstanceDebugHoverable {
         debugMessage.append(GRAY_BAR);
     }
 
+    public void append(LevelBuilder levelBuilder) {
+        debugMessage.append(Component.newline());
+        debugMessage.append(levelBuilder.build());
+    }
+
     public void namedValue(String title, float value) {
         namedValue(title, NumberFormat.addCommaAndRoundHundredths(value));
     }
 
     public void cooldown(AbstractCooldown<?> cooldown) {
 
-    }
-
-    public void append(LevelBuilder levelBuilder) {
-        debugMessage.append(Component.newline());
-        debugMessage.append(levelBuilder.build());
     }
 
     public void append(Component component) {
@@ -150,6 +153,37 @@ public class InstanceDebugHoverable {
             for (int i = 1; i < debugInfo.size(); i++) {
                 Component component = debugInfo.get(i);
                 builder.append(Component.newline()).append(spacer).append(component);
+            }
+            this.value = builder.build();
+            return this;
+        }
+
+        public LevelBuilder value(MultiFloatModifiable multiFloatModifiable) {
+            TextComponent spacer = Component.text(frontSpacing + " ".repeat(Math.max(0, (level + 2) * 2)));
+            TextComponent spacer2 = Component.text(frontSpacing + " ".repeat(Math.max(0, (level + 1) * 2)));
+            Map<MultiFloatModifiable.ApplyFloatModifiable, Map<String, Float>> globalMarginalContributions = multiFloatModifiable.getGlobalMarginalContributions();
+            ComponentBuilder builder = ComponentBuilder.create(NumberFormat.formatOptionalHundredths(multiFloatModifiable.getCalculatedValue()), NamedTextColor.GOLD);
+            builder.newLine();
+            Iterator<Map.Entry<MultiFloatModifiable.ApplyFloatModifiable, FloatModifiable>> iterator = multiFloatModifiable
+                    .getModifiables()
+                    .entrySet()
+                    .iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<MultiFloatModifiable.ApplyFloatModifiable, FloatModifiable> entry = iterator.next();
+                MultiFloatModifiable.ApplyFloatModifiable applyFloatModifiable = entry.getKey();
+                FloatModifiable floatModifiable = entry.getValue();
+                ComponentBuilder modifierDebug = ComponentBuilder
+                        .create(spacer2)
+                        .text(applyFloatModifiable.priority() + " - " + applyFloatModifiable.applyType(), NamedTextColor.DARK_PURPLE);
+                Map<String, Float> contributions = globalMarginalContributions.get(applyFloatModifiable);
+                List<Component> debugInfo = floatModifiable.getDebugInfo(contributions);
+                for (Component component : debugInfo) {
+                    modifierDebug.append(Component.newline()).append(spacer).append(component);
+                }
+                builder.append(modifierDebug.build());
+                if (iterator.hasNext()) {
+                    builder.newLine();
+                }
             }
             this.value = builder.build();
             return this;

--- a/src/main/java/com/ebicep/warlords/player/ingame/instances/InstanceDebugHoverable.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/instances/InstanceDebugHoverable.java
@@ -56,8 +56,10 @@ public class InstanceDebugHoverable {
                 .create(1)
                 .prefix(ComponentBuilder.create("Crit Multiplier: ", NamedTextColor.LIGHT_PURPLE))
                 .value(event.getCritMultiplier()));
-        grayDash();
-        namedValue("Flags", "" + event.getFlags());
+        if (!event.getFlags().isEmpty()) {
+            grayDash();
+            namedValue("Flags", "" + event.getFlags());
+        }
     }
 
     public void grayDash() {

--- a/src/main/java/com/ebicep/warlords/player/ingame/instances/InstanceManager.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/instances/InstanceManager.java
@@ -15,21 +15,21 @@ import java.util.function.Consumer;
 public class InstanceManager {
 
     public static Consumer<FloatModifiable.FloatModifier> TARGET_LABEL = floatModifier ->
-            floatModifier.setDebugPrefix(ComponentBuilder.create("(Target) ", NamedTextColor.DARK_GREEN));
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(TGT) ", NamedTextColor.DARK_GREEN));
     public static Consumer<FloatModifiable.FloatModifier> SOURCE_LABEL = floatModifier ->
-            floatModifier.setDebugPrefix(ComponentBuilder.create("(Source) ", NamedTextColor.DARK_RED));
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(SRC) ", NamedTextColor.DARK_RED));
     public static Consumer<FloatModifiable.FloatModifier> TARGET_LABEL_BI = floatModifier ->
-            floatModifier.setDebugPrefix(ComponentBuilder.create("(BI) ", NamedTextColor.AQUA).text("(Target) ", NamedTextColor.DARK_GREEN));
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(BI) ", NamedTextColor.AQUA).text("(TGT) ", NamedTextColor.DARK_GREEN));
     public static Consumer<FloatModifiable.FloatModifier> SOURCE_LABEL_BI = floatModifier ->
-            floatModifier.setDebugPrefix(ComponentBuilder.create("(BI) ", NamedTextColor.AQUA).text("(Source) ", NamedTextColor.DARK_RED));
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(BI) ", NamedTextColor.AQUA).text("(SRC) ", NamedTextColor.DARK_RED));
     public static Consumer<FloatModifiable.FloatModifier> TARGET_LABEL_AI = floatModifier ->
-            floatModifier.setDebugPrefix(ComponentBuilder.create("(AI) ", NamedTextColor.AQUA).text("(Target) ", NamedTextColor.DARK_GREEN));
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(AI) ", NamedTextColor.AQUA).text("(TGT) ", NamedTextColor.DARK_GREEN));
     public static Consumer<FloatModifiable.FloatModifier> SOURCE_LABEL_AI = floatModifier ->
-            floatModifier.setDebugPrefix(ComponentBuilder.create("(AI) ", NamedTextColor.AQUA).text("(Source) ", NamedTextColor.DARK_RED));
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(AI) ", NamedTextColor.AQUA).text("(SRC) ", NamedTextColor.DARK_RED));
     public static Consumer<FloatModifiable.FloatModifier> TARGET_LABEL_AA = floatModifier ->
-            floatModifier.setDebugPrefix(ComponentBuilder.create("(AA) ", NamedTextColor.AQUA).text("(Target) ", NamedTextColor.DARK_GREEN));
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(AA) ", NamedTextColor.AQUA).text("(TGT) ", NamedTextColor.DARK_GREEN));
     public static Consumer<FloatModifiable.FloatModifier> SOURCE_LABEL_AA = floatModifier ->
-            floatModifier.setDebugPrefix(ComponentBuilder.create("(AA) ", NamedTextColor.AQUA).text("(Source) ", NamedTextColor.DARK_RED));
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(AA) ", NamedTextColor.AQUA).text("(SRC) ", NamedTextColor.DARK_RED));
 
     public static Optional<WarlordsDamageHealingFinalEvent> addDamageHealingInstance(WarlordsDamageHealingEvent event) {
         if (event.getWarlordsEntity().isDead()) {

--- a/src/main/java/com/ebicep/warlords/player/ingame/instances/InstanceManager.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/instances/InstanceManager.java
@@ -14,12 +14,22 @@ import java.util.function.Consumer;
 
 public class InstanceManager {
 
-    public static Consumer<FloatModifiable.FloatModifier> TARGET_LABEL = floatModifier -> floatModifier.setDebugPrefix(ComponentBuilder.create("(Target) ",
-            NamedTextColor.DARK_GREEN
-    ));
-    public static Consumer<FloatModifiable.FloatModifier> SOURCE_LABEL = floatModifier -> floatModifier.setDebugPrefix(ComponentBuilder.create("(Source) ",
-            NamedTextColor.DARK_RED
-    ));
+    public static Consumer<FloatModifiable.FloatModifier> TARGET_LABEL = floatModifier ->
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(Target) ", NamedTextColor.DARK_GREEN));
+    public static Consumer<FloatModifiable.FloatModifier> SOURCE_LABEL = floatModifier ->
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(Source) ", NamedTextColor.DARK_RED));
+    public static Consumer<FloatModifiable.FloatModifier> TARGET_LABEL_BI = floatModifier ->
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(BI) ", NamedTextColor.AQUA).text("(Target) ", NamedTextColor.DARK_GREEN));
+    public static Consumer<FloatModifiable.FloatModifier> SOURCE_LABEL_BI = floatModifier ->
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(BI) ", NamedTextColor.AQUA).text("(Source) ", NamedTextColor.DARK_RED));
+    public static Consumer<FloatModifiable.FloatModifier> TARGET_LABEL_AI = floatModifier ->
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(AI) ", NamedTextColor.AQUA).text("(Target) ", NamedTextColor.DARK_GREEN));
+    public static Consumer<FloatModifiable.FloatModifier> SOURCE_LABEL_AI = floatModifier ->
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(AI) ", NamedTextColor.AQUA).text("(Source) ", NamedTextColor.DARK_RED));
+    public static Consumer<FloatModifiable.FloatModifier> TARGET_LABEL_AA = floatModifier ->
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(AA) ", NamedTextColor.AQUA).text("(Target) ", NamedTextColor.DARK_GREEN));
+    public static Consumer<FloatModifiable.FloatModifier> SOURCE_LABEL_AA = floatModifier ->
+            floatModifier.setDebugPrefix(ComponentBuilder.create("(AA) ", NamedTextColor.AQUA).text("(Source) ", NamedTextColor.DARK_RED));
 
     public static Optional<WarlordsDamageHealingFinalEvent> addDamageHealingInstance(WarlordsDamageHealingEvent event) {
         if (event.getWarlordsEntity().isDead()) {

--- a/src/main/java/com/ebicep/warlords/player/ingame/instances/type/Modifier.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/instances/type/Modifier.java
@@ -2,6 +2,7 @@ package com.ebicep.warlords.player.ingame.instances.type;
 
 import com.ebicep.warlords.events.player.ingame.WarlordsDamageHealingEvent;
 import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.MultiFloatModifiable;
 
 @SuppressWarnings("InstantiationOfUtilityClass")
 public class Modifier<T> {
@@ -145,14 +146,14 @@ public class Modifier<T> {
     @FunctionalInterface
     public interface DamageModifyBeforeInterveneFromSelf {
 
-        void apply(WarlordsDamageHealingEvent event, FloatModifiable currentDamageValue);
+        void apply(WarlordsDamageHealingEvent event, MultiFloatModifiable currentDamageValue);
 
     }
 
     @FunctionalInterface
     public interface DamageModifyBeforeInterveneFromAttacker {
 
-        void apply(WarlordsDamageHealingEvent event, FloatModifiable currentDamageValue);
+        void apply(WarlordsDamageHealingEvent event, MultiFloatModifiable currentDamageValue);
 
     }
 
@@ -166,14 +167,14 @@ public class Modifier<T> {
     @FunctionalInterface
     public interface DamageModifyAfterInterveneFromSelf {
 
-        void apply(WarlordsDamageHealingEvent event, FloatModifiable currentDamageValue);
+        void apply(WarlordsDamageHealingEvent event, MultiFloatModifiable currentDamageValue);
 
     }
 
     @FunctionalInterface
     public interface DamageModifyAfterInterveneFromAttacker {
 
-        void apply(WarlordsDamageHealingEvent event, FloatModifiable currentDamageValue);
+        void apply(WarlordsDamageHealingEvent event, MultiFloatModifiable currentDamageValue);
 
     }
 
@@ -194,7 +195,7 @@ public class Modifier<T> {
     @FunctionalInterface
     public interface DamageModifyAfterAllFromSelf {
 
-        void apply(WarlordsDamageHealingEvent event, FloatModifiable currentDamageValue, boolean isCrit);
+        void apply(WarlordsDamageHealingEvent event, MultiFloatModifiable currentDamageValue, boolean isCrit);
 
     }
 
@@ -250,14 +251,14 @@ public class Modifier<T> {
     @FunctionalInterface
     public interface HealingModifyFromSelf {
 
-        void apply(WarlordsDamageHealingEvent event, FloatModifiable currentHealValue);
+        void apply(WarlordsDamageHealingEvent event, MultiFloatModifiable currentHealValue);
 
     }
 
     @FunctionalInterface
     public interface HealingModifyFromAttacker {
 
-        void apply(WarlordsDamageHealingEvent event, FloatModifiable currentHealValue);
+        void apply(WarlordsDamageHealingEvent event, MultiFloatModifiable currentHealValue);
 
     }
 

--- a/src/main/java/com/ebicep/warlords/player/ingame/motionsystem/speed/BaseToWalkingSpeedValueModifier.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/motionsystem/speed/BaseToWalkingSpeedValueModifier.java
@@ -2,6 +2,7 @@ package com.ebicep.warlords.player.ingame.motionsystem.speed;
 
 import com.ebicep.warlords.player.ingame.motionsystem.MotionSystem;
 import com.ebicep.warlords.player.ingame.motionsystem.motionaddon.NewValueModifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class BaseToWalkingSpeedValueModifier implements NewValueModifier {
 
@@ -25,8 +26,8 @@ public class BaseToWalkingSpeedValueModifier implements NewValueModifier {
 
     @Override
     public void modifyNewValue(MotionSystem.NewValueData newValueData) {
-//        floatModifiable.addMultiplicativeModifierMult(addonName() + " - Base Speed", BASE_SPEED);
-        newValueData.newValue().addMultiplicativeModifierMult(addonName() + " - Base Walk Speed", baseWalkSpeed);
+//        floatModifiable.addModifier(addonName() + " - Base Speed", BASE_SPEED);
+        newValueData.newValue().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, addonName() + " - Base Walk Speed", baseWalkSpeed);
     }
 
     @Override

--- a/src/main/java/com/ebicep/warlords/player/ingame/motionsystem/speed/ConditionalStackValueModifier.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/motionsystem/speed/ConditionalStackValueModifier.java
@@ -2,6 +2,7 @@ package com.ebicep.warlords.player.ingame.motionsystem.speed;
 
 import com.ebicep.warlords.player.ingame.motionsystem.MotionSystem;
 import com.ebicep.warlords.player.ingame.motionsystem.motionaddon.NewValueModifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class ConditionalStackValueModifier implements NewValueModifier {
 
@@ -24,7 +25,7 @@ public class ConditionalStackValueModifier implements NewValueModifier {
     @Override
     public void modifyNewValue(MotionSystem.NewValueData newValueData) {
         if (newValueData.min() != multiplier) {
-            newValueData.newValue().addMultiplicativeModifierMult(addonName(), multiplier);
+            newValueData.newValue().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, addonName(), multiplier);
         }
     }
 

--- a/src/main/java/com/ebicep/warlords/player/ingame/motionsystem/speed/MidSpeedReductionValueModifier.java
+++ b/src/main/java/com/ebicep/warlords/player/ingame/motionsystem/speed/MidSpeedReductionValueModifier.java
@@ -14,7 +14,7 @@ public class MidSpeedReductionValueModifier implements NewValueModifier {
         float min = newValueData.min();
         FloatModifiable newValue = newValueData.newValue();
         if (min != 1 && newValue.getCalculatedValue() < speedThreshold) {
-            newValue.addAdditiveModifier(addonName(), -speedReduction); // TODO
+            newValue.addModifier(FloatModifiable.ModifierType.ADDITIVE, addonName(), -speedReduction); // TODO
         }
     }
 

--- a/src/main/java/com/ebicep/warlords/pve/items/statpool/BasicStatPool.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/statpool/BasicStatPool.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.custom.ItemAdditiveCooldown;
 import com.ebicep.warlords.pve.items.ItemTier;
 import com.ebicep.warlords.util.java.NumberFormat;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
@@ -14,7 +15,7 @@ public enum BasicStatPool implements StatPool {
     HP("Health") {
         @Override
         public void applyToWarlordsPlayer(WarlordsPlayer warlordsPlayer, float value, ItemTier highestTier) {
-            warlordsPlayer.getHealth().addAdditiveModifier("Item " + getName() + " (Base)", value);
+            warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Item " + getName() + " (Base)", value);
         }
 
         @Override
@@ -30,7 +31,7 @@ public enum BasicStatPool implements StatPool {
     MAX_ENERGY("Max Energy") {
         @Override
         public void applyToWarlordsPlayer(WarlordsPlayer warlordsPlayer, float value, ItemTier highestTier) {
-            warlordsPlayer.getEnergy().addAdditiveModifier("Item Basic Stat Pool", value);
+            warlordsPlayer.getEnergy().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Item Basic Stat Pool", value);
         }
 
         @Override
@@ -46,7 +47,7 @@ public enum BasicStatPool implements StatPool {
     EPH("Energy Per Hit") {
         @Override
         public void applyToWarlordsPlayer(WarlordsPlayer warlordsPlayer, float value, ItemTier highestTier) {
-            warlordsPlayer.getEnergyPerHit().addAdditiveModifier("Item Basic Stat Pool", value);
+            warlordsPlayer.getEnergyPerHit().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Item Basic Stat Pool", value);
         }
 
         @Override

--- a/src/main/java/com/ebicep/warlords/pve/items/statpool/SpecialStatPool.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/statpool/SpecialStatPool.java
@@ -3,13 +3,14 @@ package com.ebicep.warlords.pve.items.statpool;
 import com.ebicep.warlords.abilities.internal.AbstractAbility;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.pve.items.ItemTier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public enum SpecialStatPool implements StatPool {
 
     EPS {
         @Override
         public void applyToWarlordsPlayer(WarlordsPlayer warlordsPlayer, float value, ItemTier highestTier) {
-            warlordsPlayer.getEnergyPerSec().addAdditiveModifier("Item Special Stat Pool", value);
+            warlordsPlayer.getEnergyPerSec().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Item Special Stat Pool", value);
         }
 
         @Override
@@ -21,14 +22,14 @@ public enum SpecialStatPool implements StatPool {
     EPH {
         @Override
         public void applyToWarlordsPlayer(WarlordsPlayer warlordsPlayer, float value, ItemTier highestTier) {
-            warlordsPlayer.getEnergyPerHit().addMultiplicativeModifierAdd("Item Special Stat Pool", value / 100f);
+            warlordsPlayer.getEnergyPerHit().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Item Special Stat Pool", value / 100f);
         }
 
     },
     MAX_ENERGY {
         @Override
         public void applyToWarlordsPlayer(WarlordsPlayer warlordsPlayer, float value, ItemTier highestTier) {
-            warlordsPlayer.getEnergy().addMultiplicativeModifierAdd("Item Special Stat Pool", value / 100f);
+            warlordsPlayer.getEnergy().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Item Special Stat Pool", value / 100f);
         }
 
     },
@@ -36,7 +37,7 @@ public enum SpecialStatPool implements StatPool {
         @Override
         public void applyToAbility(AbstractAbility ability, float value, ItemTier highestTier) {
             float calculatedValue = 1 - value / 100f;
-            ability.getCooldown().addMultiplicativeModifierMult("Item Special Stat Pool", calculatedValue);
+            ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Item Special Stat Pool", calculatedValue);
         }
 
     },

--- a/src/main/java/com/ebicep/warlords/pve/items/types/fixeditems/DisasterFragment.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/fixeditems/DisasterFragment.java
@@ -19,6 +19,7 @@ import com.ebicep.warlords.pve.items.types.AbstractFixedItem;
 import com.ebicep.warlords.pve.items.types.ItemType;
 import com.ebicep.warlords.util.java.RandomCollection;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.title.Title;
@@ -125,7 +126,7 @@ public class DisasterFragment extends AbstractFixedItem implements FixedItemAppl
                                     }
                                 })
                         ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (e, currentDamageValue) -> {
-                                    currentDamageValue.addMultiplicativeModifierMult("Disaster Fragment - Burn", 1.2f);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Disaster Fragment - Burn", 1.2f);
                                 }
                         ));
                     }
@@ -155,7 +156,7 @@ public class DisasterFragment extends AbstractFixedItem implements FixedItemAppl
                                     }
                                 })
                         ).addModifier(Modifier.MODIFY_INCOMING_HEALING, (e, currentHealValue) -> {
-                                    currentHealValue.addMultiplicativeModifierMult("Disaster Fragment - Bleed", 0.2f);
+                            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Disaster Fragment - Bleed", 0.2f);
                                 }
                         ));
                     }

--- a/src/main/java/com/ebicep/warlords/pve/items/types/fixeditems/ShawlOfMithra.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/fixeditems/ShawlOfMithra.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AbstractFixedItem;
 import com.ebicep.warlords.pve.items.types.ItemType;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -52,7 +53,7 @@ public class ShawlOfMithra extends AbstractFixedItem implements FixedItemApplies
                     WarlordsEntity attacker = event.getSource();
                     if (attacker instanceof WarlordsNPC warlordsNPC) {
                         if (warlordsNPC.getMob().getInternalLevel() < 2) {
-                            currentDamageValue.addMultiplicativeModifierMult(getName(), 0.9f);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 0.9f);
                         }
                     }
                 }

--- a/src/main/java/com/ebicep/warlords/pve/items/types/fixeditems/SpiderGauntlet.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/fixeditems/SpiderGauntlet.java
@@ -17,6 +17,7 @@ import com.ebicep.warlords.pve.mobs.events.spidersburrow.EventEggSac;
 import com.ebicep.warlords.pve.mobs.flags.Spider;
 import com.ebicep.warlords.util.pve.SkullID;
 import com.ebicep.warlords.util.pve.SkullUtils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
@@ -59,7 +60,7 @@ public class SpiderGauntlet extends AbstractFixedItem implements FixedItemApplie
                     if (victim instanceof WarlordsNPC warlordsNPC && Objects.equals(attacker, warlordsPlayer)) {
                         AbstractMob mob = warlordsNPC.getMob();
                         if (mob instanceof Spider || mob instanceof EventEggSac || mob instanceof EggSac) {
-                            currentDamageValue.addMultiplicativeModifierMult(getName(), 1.1f);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1.1f);
                         }
                     }
                 }

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/delta/AerialAegis.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/delta/AerialAegis.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.pve.items.types.AbstractItem;
 import com.ebicep.warlords.pve.items.types.specialitems.CraftsInto;
 import com.ebicep.warlords.pve.items.types.specialitems.buckler.omega.CrescentBulwark;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
@@ -47,7 +48,7 @@ public class AerialAegis extends SpecialDeltaBuckler implements CraftsInto {
                 false
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                     if (!warlordsPlayer.getEntity().isOnGround()) {
-                        currentDamageValue.addMultiplicativeModifierMult(getName(), 0.8f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 0.8f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/delta/CrossNecklaceCharm.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/delta/CrossNecklaceCharm.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.pve.items.types.AbstractItem;
 import com.ebicep.warlords.pve.items.types.specialitems.CraftsInto;
 import com.ebicep.warlords.pve.items.types.specialitems.buckler.omega.BreastplateBuckler;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Set;
 
@@ -68,7 +69,9 @@ public class CrossNecklaceCharm extends SpecialDeltaBuckler implements CraftsInt
                                                 },
                                                 3
                                         ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                                    currentDamageValue.addMultiplicativeModifierMult(getName() + " Damage", 1.1f);
+                                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                                    getName() + " Damage", 1.1f
+                                            );
                                                 }
                                         ));
                                     });

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/delta/OtherworldlyAmulet.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/delta/OtherworldlyAmulet.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AbstractItem;
 import com.ebicep.warlords.pve.items.types.specialitems.CraftsInto;
 import com.ebicep.warlords.pve.items.types.specialitems.buckler.omega.LovelyOmamori;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.List;
 import java.util.Set;
@@ -50,7 +51,7 @@ public class OtherworldlyAmulet extends SpecialDeltaBuckler implements CraftsInt
         ).addModifier(Modifier.MODIFY_OUTGOING_CRIT_CHANCE, (event, currentCritChance) -> {
                     for (String effect : EFFECTS) {
                         if (warlordsPlayer.getCooldownManager().hasCooldownFromName(effect)) {
-                            currentCritChance.addAdditiveModifier(getName(), 25f);
+                            currentCritChance.addModifier(FloatModifiable.ModifierType.ADDITIVE, getName(), 25f);
                         }
                     }
                 }

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/delta/PridwensBulwark.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/delta/PridwensBulwark.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.pve.items.types.AbstractItem;
 import com.ebicep.warlords.pve.items.types.specialitems.CraftsInto;
 import com.ebicep.warlords.pve.items.types.specialitems.buckler.omega.AthenianAegis;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -73,7 +74,7 @@ public class PridwensBulwark extends SpecialDeltaBuckler implements CraftsInto {
                         }.runTaskLater(event.getCause().equals("Seismic Wave") ? 3 : 0);
                     } else if (Objects.equals(event.getCause(), "Reckless Charge")) {
                         event.applyToMinMax(floatModifiable ->
-                                floatModifiable.addMultiplicativeModifierMult(getName(), 1.25f)
+                                floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1.25f)
                         );
                     }
                 }

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/delta/ShieldOfSnatching.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/delta/ShieldOfSnatching.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AbstractItem;
 import com.ebicep.warlords.pve.items.types.specialitems.CraftsInto;
 import com.ebicep.warlords.pve.items.types.specialitems.buckler.omega.ChakramOfBlades;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Set;
 
@@ -54,7 +55,7 @@ public class ShieldOfSnatching extends SpecialDeltaBuckler implements CraftsInto
                                                                .warlordsPlayers()
                                                                .filter(p -> p.getCurrentHealth() / p.getMaxHealth() < 0.75)
                                                                .count();
-                    currentHealValue.addMultiplicativeModifierMult(getName(), (1 + playersBelowThreshold * 0.08f));
+            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), (1 + playersBelowThreshold * 0.08f));
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/omega/AthenianAegis.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/omega/AthenianAegis.java
@@ -7,6 +7,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AppliesToWarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Set;
 
@@ -48,7 +49,7 @@ public class AthenianAegis extends SpecialOmegaBuckler implements AppliesToWarlo
                 false
         ).addModifier(Modifier.MODIFY_OUTGOING_HEALING, (event, currentHealValue) -> {
                     int mobCount = pveOption.mobCount();
-                    currentHealValue.addMultiplicativeModifierMult(getName(), 1 + (mobCount * .005f));
+            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1 + (mobCount * .005f));
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/omega/BreastplateBuckler.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/omega/BreastplateBuckler.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AppliesToWarlordsPlayer;
 import com.ebicep.warlords.pve.mobs.AbstractMob;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Map;
 import java.util.Set;
@@ -61,7 +62,7 @@ public class BreastplateBuckler extends SpecialOmegaBuckler implements AppliesTo
                         AbstractMob mob = warlordsNPC.getMob();
                         float damageReduction = Math.max(1 - (repeatedAttacks.getOrDefault(mob, 0) * 0.02f), 0.8f);
                         repeatedAttacks.merge(mob, 1, Integer::sum);
-                        currentDamageValue.addMultiplicativeModifierMult(getName(), damageReduction);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), damageReduction);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/omega/CrescentBulwark.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/omega/CrescentBulwark.java
@@ -7,6 +7,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AppliesToWarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Set;
 
@@ -48,7 +49,7 @@ public class CrescentBulwark extends SpecialOmegaBuckler implements AppliesToWar
                 false
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     int mobCount = pveOption.mobCount();
-                    currentDamageValue.addMultiplicativeModifierMult(getName(), 1 + (mobCount * .005f));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1 + (mobCount * .005f));
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/omega/ElementalShield.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/buckler/omega/ElementalShield.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.game.option.pve.PveOption;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AppliesToWarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Set;
 
@@ -33,7 +34,7 @@ public class ElementalShield extends SpecialOmegaBuckler implements AppliesToWar
 
     @Override
     public void applyToWarlordsPlayer(WarlordsPlayer warlordsPlayer, PveOption pveOption) {
-        warlordsPlayer.getHealth().addMultiplicativeModifierAdd(getName(), 0.125f);
+        warlordsPlayer.getHealth().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, getName(), 0.125f);
     }
 
 }

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/delta/DiabolicalRings.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/delta/DiabolicalRings.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AbstractItem;
 import com.ebicep.warlords.pve.items.types.AppliesToWarlordsPlayer;
 import com.ebicep.warlords.pve.items.types.specialitems.gauntlets.omega.MonaLisasPalms;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -39,7 +40,7 @@ public class DiabolicalRings extends SpecialDeltaGauntlet implements AppliesToWa
                 false
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (!event.getWarlordsEntity().equals(warlordsPlayer) && ThreadLocalRandom.current().nextDouble() <= 0.1) {
-                        currentDamageValue.addMultiplicativeModifierMult(getName(), 1.25f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1.25f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/delta/GardeningGloves.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/delta/GardeningGloves.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AbstractItem;
 import com.ebicep.warlords.pve.items.types.AppliesToWarlordsPlayer;
 import com.ebicep.warlords.pve.items.types.specialitems.gauntlets.omega.NaturesClaws;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -39,7 +40,7 @@ public class GardeningGloves extends SpecialDeltaGauntlet implements AppliesToWa
                 false
         ).addModifier(Modifier.MODIFY_OUTGOING_HEALING, (event, currentHealValue) -> {
                     if (ThreadLocalRandom.current().nextDouble() <= .15) {
-                        currentHealValue.addMultiplicativeModifierMult(getName(), 1.3f);
+                        currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1.3f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/delta/SamsonsFists.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/delta/SamsonsFists.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AbstractItem;
 import com.ebicep.warlords.pve.items.types.AppliesToWarlordsPlayer;
 import com.ebicep.warlords.pve.items.types.specialitems.gauntlets.omega.HandsOfTheHolyCorpse;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Set;
 
@@ -38,7 +39,7 @@ public class SamsonsFists extends SpecialDeltaGauntlet implements AppliesToWarlo
                 false
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (event.getCause().isEmpty()) {
-                        currentDamageValue.addMultiplicativeModifierMult(getName(), 1.4f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1.4f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/omega/HandsOfTheHolyCorpse.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/omega/HandsOfTheHolyCorpse.java
@@ -4,6 +4,7 @@ import com.ebicep.warlords.game.option.pve.PveOption;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AppliesToWarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Set;
 
@@ -34,7 +35,7 @@ public class HandsOfTheHolyCorpse extends SpecialOmegaGauntlet implements Applie
 
     @Override
     public void applyToWarlordsPlayer(WarlordsPlayer warlordsPlayer, PveOption pveOption) {
-        warlordsPlayer.getEnergyPerHit().addAdditiveModifier(getName(), 12);
+        warlordsPlayer.getEnergyPerHit().addModifier(FloatModifiable.ModifierType.ADDITIVE, getName(), 12);
     }
 
 }

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/omega/MonaLisasPalms.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/omega/MonaLisasPalms.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AppliesToWarlordsPlayer;
 import com.ebicep.warlords.pve.mobs.flags.BossLike;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -70,7 +71,7 @@ public class MonaLisasPalms extends SpecialOmegaGauntlet implements AppliesToWar
                         return;
                     }
                     event.applyToMinMax(floatModifiable ->
-                            floatModifiable.addOverridingModifier(getName(), warlordsEntity.getCurrentHealth() + 1)
+                            floatModifiable.addModifier(FloatModifiable.ModifierType.OVERRIDING, getName(), warlordsEntity.getCurrentHealth() + 1)
                     );
                     event.getFlags().add(InstanceFlags.IGNORE_SELF_RES);
                     event.getFlags().add(InstanceFlags.TRUE_DAMAGE);

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/omega/NaturesClaws.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/omega/NaturesClaws.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.game.option.pve.PveOption;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AppliesToWarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Set;
 
@@ -35,7 +36,7 @@ public class NaturesClaws extends SpecialOmegaGauntlet implements AppliesToWarlo
     @Override
     public void applyToWarlordsPlayer(WarlordsPlayer warlordsPlayer, PveOption pveOption) {
         for (AbstractAbility ability : warlordsPlayer.getAbilities()) {
-            ability.getCooldown().addMultiplicativeModifierAdd(getName(), -0.1f);
+            ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, getName(), -0.1f);
         }
     }
 

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/omega/RobinHoodsGloves.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/gauntlets/omega/RobinHoodsGloves.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AppliesToWarlordsPlayer;
 import com.ebicep.warlords.pve.mobs.flags.BossLike;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -69,7 +70,7 @@ public class RobinHoodsGloves extends SpecialOmegaGauntlet implements AppliesToW
                         return;
                     }
                     event.applyToMinMax(floatModifiable ->
-                            floatModifiable.addOverridingModifier(getName(), warlordsEntity.getCurrentHealth() + 1)
+                            floatModifiable.addModifier(FloatModifiable.ModifierType.OVERRIDING, getName(), warlordsEntity.getCurrentHealth() + 1)
                     );
                     event.getFlags().add(InstanceFlags.IGNORE_SELF_RES);
                     event.getFlags().add(InstanceFlags.TRUE_DAMAGE);

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/tome/delta/AGuideToMMA.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/tome/delta/AGuideToMMA.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.pve.items.types.AbstractItem;
 import com.ebicep.warlords.pve.items.types.specialitems.CraftsInto;
 import com.ebicep.warlords.pve.items.types.specialitems.tome.omega.ScrollOfScripts;
 import com.ebicep.warlords.pve.mobs.flags.BossLike;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Set;
 
@@ -54,7 +55,7 @@ public class AGuideToMMA extends SpecialDeltaTome implements CraftsInto {
                 false
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (event.getWarlordsEntity() instanceof WarlordsNPC warlordsNPC && warlordsNPC.getMob() instanceof BossLike) {
-                        currentDamageValue.addMultiplicativeModifierMult(getName(), 1.15f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1.15f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/tome/delta/FirewaterAlmanac.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/tome/delta/FirewaterAlmanac.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AbstractItem;
 import com.ebicep.warlords.pve.items.types.specialitems.CraftsInto;
 import com.ebicep.warlords.pve.items.types.specialitems.tome.omega.FlemingAlmanac;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.entity.Entity;
 
 import java.util.Set;
@@ -60,7 +61,7 @@ public class FirewaterAlmanac extends SpecialDeltaTome implements CraftsInto {
                                             })
                                             .sum();
                     targeted = Math.min(10, targeted);
-                    currentDamageValue.addMultiplicativeModifierMult(getName(), (1 - (targeted * 0.01f)));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), (1 - (targeted * 0.01f)));
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/tome/omega/ScrollOfScripts.java
+++ b/src/main/java/com/ebicep/warlords/pve/items/types/specialitems/tome/omega/ScrollOfScripts.java
@@ -7,6 +7,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.items.statpool.BasicStatPool;
 import com.ebicep.warlords.pve.items.types.AppliesToWarlordsPlayer;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import java.util.Set;
 
@@ -49,7 +50,7 @@ public class ScrollOfScripts extends SpecialOmegaTome implements AppliesToWarlor
                 },
                 false
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(getName(), 1 + 0.05f * numberOfPlayersAbove75(warlordsPlayer));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getName(), 1 + 0.05f * numberOfPlayersAbove75(warlordsPlayer));
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/pve/mobs/Aspect.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/Aspect.java
@@ -61,7 +61,7 @@ public enum Aspect {
                     }
             ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                         if (!Aspect.isNegated(warlordsEntity)) {
-                            currentDamageValue.addMultiplicativeModifierMult("Aspect - Armoured", 0.6f);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Aspect - Armoured", 0.6f);
                         }
                     }
             ));
@@ -189,7 +189,7 @@ public enum Aspect {
                                 })
                         ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (e, currentDamageValue2) -> {
                                     if (!Aspect.isNegated(warlordsEntity)) {
-                                        currentDamageValue2.addMultiplicativeModifierMult("Aspect - Burn", 1.2f);
+                                        currentDamageValue2.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Aspect - Burn", 1.2f);
                                     }
                                 }
                         ));
@@ -201,7 +201,9 @@ public enum Aspect {
         @Override
         public void apply(WarlordsEntity warlordsEntity) {
             float additionalHealth = warlordsEntity.getMaxBaseHealth() * .5f;
-            AtomicReference<FloatModifiable.FloatModifier> modifier = new AtomicReference<>(warlordsEntity.getHealth().addAdditiveModifier(name + " (Base)", additionalHealth));
+            AtomicReference<FloatModifiable.FloatModifier> modifier = new AtomicReference<>(warlordsEntity.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                    name + " (Base)", additionalHealth
+            ));
             warlordsEntity.heal();
             AtomicBoolean hasEffect = new AtomicBoolean(true);
             warlordsEntity.getCooldownManager().addCooldown(new PermanentCooldown<>(
@@ -222,7 +224,7 @@ public enum Aspect {
                             }
                         } else if (!hasEffect.get()) {
                             hasEffect.set(true);
-                            modifier.set(warlordsEntity.getHealth().addAdditiveModifier(name + " (Base)", additionalHealth));
+                            modifier.set(warlordsEntity.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, name + " (Base)", additionalHealth));
                         }
                     }
             ));

--- a/src/main/java/com/ebicep/warlords/pve/mobs/bosses/Chessking.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/bosses/Chessking.java
@@ -14,6 +14,7 @@ import com.ebicep.warlords.pve.mobs.slime.SlimyChess;
 import com.ebicep.warlords.pve.mobs.tiers.BossMob;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.trait.SlimeSize;
 import net.kyori.adventure.text.Component;
@@ -116,7 +117,8 @@ public class Chessking extends AbstractMob implements BossMob {
             warlordsNPC.getAbilitiesMatching(Belch.class)
                        .forEach(belch -> belch.setRange(9 - ((20 - newSize) * .2f)));
             warlordsNPC.getAbilitiesMatching(SpawnMobAbility.class)
-                       .forEach(spawnMobAbility -> spawnMobAbility.getCooldown().addMultiplicativeModifierAdd("Chessking", -((20 - newSize) * .01f)));
+                       .forEach(spawnMobAbility -> spawnMobAbility.getCooldown()
+                                                                  .addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Chessking", -((20 - newSize) * .01f)));
         }
     }
 

--- a/src/main/java/com/ebicep/warlords/pve/mobs/bosses/Enavuris.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/bosses/Enavuris.java
@@ -25,6 +25,7 @@ import com.ebicep.warlords.util.bukkit.LocationUtils;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import io.papermc.paper.entity.TeleportFlag;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -447,7 +448,7 @@ public class Enavuris extends AbstractMob implements BossMob, Unsilencable, Unst
                         },
                         3 * 20
                 ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult(name, 0.75f);
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.75f);
                         }
                 ));
             }
@@ -650,7 +651,7 @@ public class Enavuris extends AbstractMob implements BossMob, Unsilencable, Unst
                 }
             }.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                         if (currentDebuff.get() == Debuff.CRIPPLE) {
-                            currentDamageValue.addMultiplicativeModifierMult(name, 0.75f);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.75f);
                         }
                     }
             ).addModifier(Modifier.ON_INCOMING_DAMAGE, (event, currentDamageValue, isCrit) -> {
@@ -668,7 +669,7 @@ public class Enavuris extends AbstractMob implements BossMob, Unsilencable, Unst
                     }
             ).addModifier(Modifier.MODIFY_INCOMING_HEALING, (event, currentHealValue) -> {
                         if (currentDebuff.get() == Debuff.WOUND) {
-                            currentHealValue.addMultiplicativeModifierMult(name, 0.75f);
+                            currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.75f);
                         }
                     }
             ));

--- a/src/main/java/com/ebicep/warlords/pve/mobs/bosses/Lilium.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/bosses/Lilium.java
@@ -33,6 +33,7 @@ import com.ebicep.warlords.util.chat.ChatUtils;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -156,7 +157,7 @@ public class Lilium extends AbstractMob implements BossMob {
                     if (crystals.isEmpty()) {
                         return;
                     }
-                    currentDamageValue.addMultiplicativeModifierMult(name, 0.1f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.1f);
                 }
         ));
 
@@ -706,14 +707,14 @@ public class Lilium extends AbstractMob implements BossMob {
                                                         },
                                                         3
                                                 ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                                                            currentDamageValue.addOverridingModifier(name, 0);
+                                                    currentDamageValue.addModifier(FloatModifiable.ModifierType.OVERRIDING, name, 0);
                                                         }
                                                 ));
                                             }
                                         }
                                     })
                             ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                                        currentDamageValue.addMultiplicativeModifierMult(name, 0.1f);
+                                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.1f);
                                     }
                             ));
                         });

--- a/src/main/java/com/ebicep/warlords/pve/mobs/bosses/MagmaticOoze.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/bosses/MagmaticOoze.java
@@ -26,6 +26,7 @@ import com.ebicep.warlords.util.java.MathUtils;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.citizensnpcs.trait.MountTrait;
 import net.citizensnpcs.trait.SlimeSize;
 import net.kyori.adventure.text.Component;
@@ -140,7 +141,7 @@ public class MagmaticOoze extends AbstractMob implements BossMob {
                 false
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (warlordsNPC.getEntity().isInsideVehicle()) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 0.6f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.6f);
                     }
                 }
         ));
@@ -499,7 +500,7 @@ public class MagmaticOoze extends AbstractMob implements BossMob {
             // increase heat / damage on every use
             if (timesUsed++ <= 40) { // ~700 max at split 0
                 damageIncrese += .05f;
-                damageValues.heatAuraDamage.value().addMultiplicativeModifierAdd(name, damageIncrese);
+                damageValues.heatAuraDamage.value().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, name, damageIncrese);
             }
             PlayerFilter.entitiesAround(wp, hitbox, hitbox, hitbox)
                         .aliveEnemiesOf(wp)

--- a/src/main/java/com/ebicep/warlords/pve/mobs/bosses/Narmer.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/bosses/Narmer.java
@@ -20,7 +20,6 @@ import com.ebicep.warlords.pve.mobs.abilities.AbstractPveAbility;
 import com.ebicep.warlords.pve.mobs.abilities.AbstractSpawnMobAbility;
 import com.ebicep.warlords.pve.mobs.abilities.SpawnMobAbility;
 import com.ebicep.warlords.pve.mobs.bosses.bossminions.NarmerAcolyte;
-import com.ebicep.warlords.pve.mobs.bosses.bossminions.NarmersDeathCharge;
 import com.ebicep.warlords.pve.mobs.flags.DynamicFlags;
 import com.ebicep.warlords.pve.mobs.tiers.BossMob;
 import com.ebicep.warlords.pve.mobs.zombie.ZombieLancer;
@@ -28,6 +27,7 @@ import com.ebicep.warlords.util.chat.ChatUtils;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -98,7 +98,7 @@ public class Narmer extends AbstractMob implements BossMob {
         if (difficulty == DifficultyIndex.ENDLESS) {
             for (AbstractAbility ability : warlordsNPC.getAbilities()) {
                 if (ability instanceof GroundShred) {
-                    ability.getCooldown().addMultiplicativeModifierAdd("Narmer Endless", -0.5f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Narmer Endless", -0.5f);
                 }
             }
         }

--- a/src/main/java/com/ebicep/warlords/pve/mobs/bosses/OneOfNine.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/bosses/OneOfNine.java
@@ -30,6 +30,7 @@ import com.ebicep.warlords.util.chat.ChatUtils;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -246,7 +247,7 @@ public class OneOfNine extends AbstractMob implements BossMob {
                     }
                     // nullify reflected damage
                     if (event.getFlags().contains(InstanceFlags.REFLECTIVE_DAMAGE)) {
-                        currentDamageValue.addOverridingModifier(name, 0f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.OVERRIDING, name, 0f);
                     } else {
                 event.getSource().addInstance(InstanceBuilder
                         .damage()
@@ -573,10 +574,10 @@ public class OneOfNine extends AbstractMob implements BossMob {
                     cooldownManager -> {},
                     true
             ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 0.7f);
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.7f);
                     }
             ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 1.5f);
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1.5f);
                     }
             ));
 

--- a/src/main/java/com/ebicep/warlords/pve/mobs/bosses/Orbyz.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/bosses/Orbyz.java
@@ -25,6 +25,7 @@ import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.PlayerFilterGeneric;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -231,9 +232,9 @@ public class Orbyz extends AbstractMob implements BossMob {
                 true
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_ALL_MODIFIERS, (event, currentDamageValue, isCrit) -> {
                     if (event.getSource().getCooldownManager().hasCooldownFromName("Empowering Allies")) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 1.2f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1.2f);
                     } else {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 0.1f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.1f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/mobs/bosses/Torment.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/bosses/Torment.java
@@ -27,6 +27,7 @@ import com.ebicep.warlords.util.chat.ChatUtils;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -114,14 +115,14 @@ public class Torment extends AbstractMob implements BossMob {
                 true
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_ALL_MODIFIERS, (event, currentDamageValue, isCrit) -> {
                     if (event.getSource().getCooldownManager().hasCooldown(DamageCheck.class)) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 3);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 3);
                     } else {
                         EffectUtils.playParticleLinkAnimation(
                                 warlordsNPC.getLocation(),
                                 event.getSource().getLocation(),
                                 Particle.SCULK_SOUL
                         );
-                        currentDamageValue.addMultiplicativeModifierMult(name, 0.4f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.4f);
                     }
                 }
         ));
@@ -194,14 +195,14 @@ public class Torment extends AbstractMob implements BossMob {
                                             },
                                             3
                                     ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                                                currentDamageValue.addOverridingModifier(name, 0);
+                                        currentDamageValue.addModifier(FloatModifiable.ModifierType.OVERRIDING, name, 0);
                                             }
                                     ));
                                 }
                             }
                         })
                 ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                            currentDamageValue.addMultiplicativeModifierMult(name, 0.05f);
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.05f);
                         }
                 ));
             }

--- a/src/main/java/com/ebicep/warlords/pve/mobs/bosses/bossminions/EchoOfBlades.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/bosses/bossminions/EchoOfBlades.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.tiers.BossMinionMob;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
 import org.bukkit.Location;
@@ -71,7 +72,7 @@ public class EchoOfBlades extends AbstractMob implements BossMinionMob {
                                 cooldownManager -> {},
                                 41
                         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                                    currentDamageValue.addMultiplicativeModifierMult(name, 0.1f);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.1f);
                                 }
                         ));
 

--- a/src/main/java/com/ebicep/warlords/pve/mobs/bosses/bossminions/NineCrystal.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/bosses/bossminions/NineCrystal.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.mobs.AbstractMob;
 import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.tiers.BossMinionMob;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
@@ -104,9 +105,9 @@ public class NineCrystal extends AbstractMob implements BossMinionMob {
                 true
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                     if (spec == event.getSource().getSpecClass().specType) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 3);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 3);
                     } else {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 0.1f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.1f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/mobs/creeper/CreepyBomber.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/creeper/CreepyBomber.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.tiers.EliteMob;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 
@@ -77,7 +78,7 @@ public class CreepyBomber extends AbstractMob implements EliteMob {
         super.onDamageTaken(self, attacker, event);
         if (Utils.isProjectile(event.getCause())) {
             event.applyToMinMax(floatModifiable ->
-                    floatModifiable.addMultiplicativeModifierMult(name, .2f)
+                    floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, .2f)
             );
         }
     }

--- a/src/main/java/com/ebicep/warlords/pve/mobs/events/gardenofhesperides/EventZeus.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/events/gardenofhesperides/EventZeus.java
@@ -22,6 +22,7 @@ import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.flags.Unsilencable;
 import com.ebicep.warlords.pve.mobs.tiers.BossMob;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -170,7 +171,7 @@ public class EventZeus extends AbstractMob implements BossMob, God, Unsilencable
                         if (event.getCause().isEmpty()) {
                             return;
                         }
-                        currentDamageValue.addMultiplicativeModifierMult(name, damageBuff);
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, damageBuff);
                     }
             ));
             return super.onActivateInternal(wp);

--- a/src/main/java/com/ebicep/warlords/pve/mobs/events/libraryarchives/EventInquisiteur.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/events/libraryarchives/EventInquisiteur.java
@@ -172,7 +172,7 @@ public abstract class EventInquisiteur extends AbstractMob implements BossMob {
                 },
                 false
         ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult("Killing Blow", (1 - damageResistance.get() / 100f));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Killing Blow", (1 - damageResistance.get() / 100f));
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/pve/mobs/events/libraryarchives/EventNecronomiconGrimoire.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/events/libraryarchives/EventNecronomiconGrimoire.java
@@ -17,6 +17,7 @@ import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.tiers.BossMinionMob;
 import com.ebicep.warlords.util.bukkit.LocationBuilder;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import fr.skytasul.guardianbeam.Laser;
 import net.citizensnpcs.trait.SkinTrait;
 import org.bukkit.Location;
@@ -97,7 +98,7 @@ public class EventNecronomiconGrimoire extends AbstractMob implements BossMinion
                 false
         ).addModifier(Modifier.MODIFY_OUTGOING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                     if (currentDamageValue.getCalculatedValue() > warlordsNPC.getMaxHealth() * .1) {
-                        currentDamageValue.addMultiplicativeModifierMult("Damage Reduction", 0.3f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Damage Reduction", 0.3f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/mobs/events/libraryarchives/EventTheArchivist.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/events/libraryarchives/EventTheArchivist.java
@@ -85,7 +85,7 @@ public class EventTheArchivist extends AbstractMob implements BossMob, Unsilenca
 
         option.getGame().registerEvents(new Listener() {
 
-            final FloatModifiable.FloatModifier modifier = warlordsNPC.getHealth().addAdditiveModifier(name + " (Base)", 0);
+            final FloatModifiable.FloatModifier modifier = warlordsNPC.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, name + " (Base)", 0);
 
             @EventHandler
             public void onAbilityUse(WarlordsAbilityActivateEvent.Post event) {
@@ -113,7 +113,7 @@ public class EventTheArchivist extends AbstractMob implements BossMob, Unsilenca
 
     @Override
     public void onDamageTaken(WarlordsEntity self, WarlordsEntity attacker, WarlordsDamageHealingEvent event) {
-        event.getCritChance().addAdditiveModifier(name, -25);
+        event.getCritChance().addModifier(FloatModifiable.ModifierType.ADDITIVE, name, -25);
     }
 
 }

--- a/src/main/java/com/ebicep/warlords/pve/mobs/events/pharaohsrevenge/EventDjer.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/events/pharaohsrevenge/EventDjer.java
@@ -17,6 +17,7 @@ import com.ebicep.warlords.pve.mobs.tiers.BossMinionMob;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilterGeneric;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
@@ -112,7 +113,7 @@ public class EventDjer extends AbstractMob implements BossMinionMob {
                     return;
                 }
                 event.applyToMinMax(floatModifiable ->
-                        floatModifiable.addMultiplicativeModifierMult(name, .75f)
+                        floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, .75f)
                 );
             }
 

--- a/src/main/java/com/ebicep/warlords/pve/mobs/events/pharaohsrevenge/EventDjet.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/events/pharaohsrevenge/EventDjet.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.abilities.AbstractPveAbility;
 import com.ebicep.warlords.pve.mobs.tiers.BossMinionMob;
 import com.ebicep.warlords.util.warlords.PlayerFilterGeneric;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 
 import javax.annotation.Nonnull;
@@ -74,7 +75,7 @@ public class EventDjet extends AbstractMob implements BossMinionMob {
     public void whileAlive(int ticksElapsed, PveOption option) {
         if (!aboveHealthThreshold() && !wentBelowHealthThreshold) {
             wentBelowHealthThreshold = true;
-            playerClass.getAbilities().get(0).getCooldown().addAdditiveModifier("Djet Health Threshold", 1000000f);
+            playerClass.getAbilities().get(0).getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Djet Health Threshold", 1000000f);
         }
     }
 

--- a/src/main/java/com/ebicep/warlords/pve/mobs/events/pharaohsrevenge/EventNarmer.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/events/pharaohsrevenge/EventNarmer.java
@@ -21,6 +21,7 @@ import com.ebicep.warlords.util.chat.ChatUtils;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -161,7 +162,7 @@ public class EventNarmer extends AbstractMob implements BossMob {
             public void onDamageHealEvent(WarlordsDamageHealingEvent event) {
                 if (event.getSource().equals(warlordsNPC)) {
                     event.applyToMinMax(floatModifiable ->
-                            floatModifiable.addMultiplicativeModifierMult(name, hpDamageIncrease)
+                            floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, hpDamageIncrease)
                     );
                 } else if (event.getWarlordsEntity().equals(warlordsNPC)) {
                     Location loc = warlordsNPC.getLocation();

--- a/src/main/java/com/ebicep/warlords/pve/mobs/events/spidersburrow/EventMithra.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/events/spidersburrow/EventMithra.java
@@ -23,6 +23,7 @@ import com.ebicep.warlords.util.chat.ChatUtils;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -305,7 +306,7 @@ public class EventMithra extends AbstractMob implements BossMob {
                     }
                 }
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(name, 1.15f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 1.15f);
                 }
         ));
         warlordsNPC.setDamageResistance(warlordsNPC.getSpec().getDamageResistance() + 10);

--- a/src/main/java/com/ebicep/warlords/pve/mobs/magmacube/Illumination.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/magmacube/Illumination.java
@@ -17,6 +17,7 @@ import com.ebicep.warlords.pve.mobs.abilities.AbstractPveAbility;
 import com.ebicep.warlords.pve.mobs.tiers.AdvancedMob;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.trait.SlimeSize;
 import org.bukkit.*;
@@ -137,7 +138,7 @@ public class Illumination extends AbstractMob implements AdvancedMob {
                             },
                             3 * 20
                     ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 0.5f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.5f);
                         }
                     ));
                 }

--- a/src/main/java/com/ebicep/warlords/pve/mobs/skeleton/CelestialBowWielder.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/skeleton/CelestialBowWielder.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.pve.mobs.AbstractMob;
 import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.tiers.AdvancedMob;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 
 public class CelestialBowWielder extends AbstractMob implements AdvancedMob {
@@ -69,7 +70,7 @@ public class CelestialBowWielder extends AbstractMob implements AdvancedMob {
                 true
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                     if (!Utils.isProjectile(event.getCause())) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 0.1f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.1f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/mobs/zombie/CelestialSwordWielder.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/zombie/CelestialSwordWielder.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.pve.mobs.AbstractMob;
 import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.tiers.EliteMob;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 
 public class CelestialSwordWielder extends AbstractMob implements EliteMob {
@@ -65,7 +66,7 @@ public class CelestialSwordWielder extends AbstractMob implements EliteMob {
                 true
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                     if (Utils.isProjectile(event.getCause())) {
-                        currentDamageValue.addMultiplicativeModifierMult(name, 0.1f);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, name, 0.1f);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/mobs/zombie/berserkzombie/AbstractBerserkZombie.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/zombie/berserkzombie/AbstractBerserkZombie.java
@@ -7,6 +7,7 @@ import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.pve.DifficultyIndex;
 import com.ebicep.warlords.pve.mobs.AbstractMob;
 import com.ebicep.warlords.util.bukkit.packets.PacketUtils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 
@@ -44,7 +45,7 @@ public abstract class AbstractBerserkZombie extends AbstractMob {
     public void onSpawn(PveOption option) {
         super.onSpawn(option);
         if (option.getDifficulty() != DifficultyIndex.EASY && option.getGame().onlinePlayersWithoutSpectators().count() == 1) {
-            woundingStrike.getHitBoxRadius().addAdditiveModifier(name, -1);
+            woundingStrike.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, name, -1);
         }
     }
 

--- a/src/main/java/com/ebicep/warlords/pve/mobs/zombie/berserkzombie/AdvancedWarriorBerserker.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/zombie/berserkzombie/AdvancedWarriorBerserker.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.tiers.AdvancedMob;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -50,8 +51,8 @@ public class AdvancedWarriorBerserker extends AbstractBerserkZombie implements A
                 new BerserkerZombieWoundingStrike()
         );
         Value.RangedValueCritable strikeDamage = woundingStrike.getDamageValues().getStrikeDamage();
-        strikeDamage.min().addMultiplicativeModifierAdd(name, .5f);
-        strikeDamage.max().addMultiplicativeModifierAdd(name, .5f);
+        strikeDamage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, name, .5f);
+        strikeDamage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, name, .5f);
     }
 
     @Override
@@ -78,7 +79,7 @@ public class AdvancedWarriorBerserker extends AbstractBerserkZombie implements A
                     }
                 }
         ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult("Berserk", 1.2f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Berserk", 1.2f);
                 }
         ));
         warlordsNPC.getCooldownManager().addCooldown(new PermanentCooldown<>(

--- a/src/main/java/com/ebicep/warlords/pve/mobs/zombie/berserkzombie/IntermediateWarriorBerserker.java
+++ b/src/main/java/com/ebicep/warlords/pve/mobs/zombie/berserkzombie/IntermediateWarriorBerserker.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.mobs.Mob;
 import com.ebicep.warlords.pve.mobs.tiers.IntermediateMob;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 
@@ -46,8 +47,8 @@ public class IntermediateWarriorBerserker extends AbstractBerserkZombie implemen
                 new BerserkerZombieWoundingStrike()
         );
         Value.RangedValueCritable strikeDamage = woundingStrike.getDamageValues().getStrikeDamage();
-        strikeDamage.min().addMultiplicativeModifierAdd(name, .25f);
-        strikeDamage.max().addMultiplicativeModifierAdd(name, .25f);
+        strikeDamage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, name, .25f);
+        strikeDamage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, name, .25f);
     }
 
     @Override
@@ -74,7 +75,7 @@ public class IntermediateWarriorBerserker extends AbstractBerserkZombie implemen
                     }
                 }
         ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult("Berserk", 1.2f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Berserk", 1.2f);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/UpgradeTreeBuilder.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/UpgradeTreeBuilder.java
@@ -60,7 +60,9 @@ public class UpgradeTreeBuilder {
 
     public UpgradeTreeBuilder addUpgradeDamage(Value ability, float value, int... levels) {
         List<FloatModifiable.FloatModifier> modifiers = new ArrayList<>();
-        ability.forEachValue(floatModifiable -> modifiers.add(floatModifiable.addMultiplicativeModifierAdd("Upgrade Branch", 0, false)));
+        ability.forEachValue(floatModifiable -> modifiers.add(floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                "Upgrade Branch", 0, false
+        )));
         return addUpgrade(
                 UpgradeTypes.DAMAGE,
                 modifiers,
@@ -71,7 +73,9 @@ public class UpgradeTreeBuilder {
 
     public UpgradeTreeBuilder addUpgradeDamage(Value.ValueHolder ability, float value, int... levels) {
         List<FloatModifiable.FloatModifier> modifiers = new ArrayList<>();
-        ability.getValues().forEach(v -> v.forEachValue(floatModifiable -> modifiers.add(floatModifiable.addMultiplicativeModifierAdd("Upgrade Branch", 0, false))));
+        ability.getValues().forEach(v -> v.forEachValue(floatModifiable -> modifiers.add(floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                "Upgrade Branch", 0, false
+        ))));
         return addUpgrade(
                 UpgradeTypes.DAMAGE,
                 modifiers,
@@ -86,7 +90,9 @@ public class UpgradeTreeBuilder {
 
     public UpgradeTreeBuilder addUpgradeHealing(Value ability, float value, int... levels) {
         List<FloatModifiable.FloatModifier> modifiers = new ArrayList<>();
-        ability.forEachValue(floatModifiable -> modifiers.add(floatModifiable.addMultiplicativeModifierAdd("Upgrade Branch", 0, false)));
+        ability.forEachValue(floatModifiable -> modifiers.add(floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                "Upgrade Branch", 0, false
+        )));
         return addUpgrade(
                 UpgradeTypes.HEALING,
                 modifiers,
@@ -97,7 +103,9 @@ public class UpgradeTreeBuilder {
 
     public UpgradeTreeBuilder addUpgradeHealing(Value.ValueHolder ability, float value, int... levels) {
         List<FloatModifiable.FloatModifier> modifiers = new ArrayList<>();
-        ability.getValues().forEach(v -> v.forEachValue(floatModifiable -> modifiers.add(floatModifiable.addMultiplicativeModifierAdd("Upgrade Branch", 0, false))));
+        ability.getValues().forEach(v -> v.forEachValue(floatModifiable -> modifiers.add(floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                "Upgrade Branch", 0, false
+        ))));
         return addUpgrade(
                 UpgradeTypes.HEALING,
                 modifiers,
@@ -113,7 +121,7 @@ public class UpgradeTreeBuilder {
     public UpgradeTreeBuilder addUpgradeCooldown(AbstractAbility ability, float value, int... levels) {
         return addUpgrade(
                 UpgradeTypes.COOLDOWN_REDUCTION,
-                ability.getCooldown().addMultiplicativeModifierAdd("Upgrade Branch", 0),
+                ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Upgrade Branch", 0),
                 value,
                 levels
         );
@@ -126,7 +134,7 @@ public class UpgradeTreeBuilder {
     public UpgradeTreeBuilder addUpgradeEnergy(AbstractAbility ability, float value, int... levels) {
         return addUpgrade(
                 UpgradeTypes.ENERGY_COST,
-                ability.getEnergyCost().addAdditiveModifier("Upgrade Branch", 0),
+                ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade Branch", 0),
                 value,
                 levels
         );
@@ -194,7 +202,7 @@ public class UpgradeTreeBuilder {
     public UpgradeTreeBuilder addUpgradeHitBox(HitBox hitBox, float value, int... levels) {
         return addUpgrade(
                 UpgradeTypes.HITBOX,
-                hitBox.getHitBoxRadius().addAdditiveModifier("Upgrade Branch", 0),
+                hitBox.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade Branch", 0),
                 value,
                 levels
         );
@@ -203,7 +211,7 @@ public class UpgradeTreeBuilder {
     public UpgradeTreeBuilder addUpgradeSplash(Splash splash, float value, int... levels) {
         return addUpgrade(
                 UpgradeTypes.SPLASH,
-                splash.getSplashRadius().addAdditiveModifier("Upgrade Branch", 0),
+                splash.getSplashRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade Branch", 0),
                 value,
                 levels
         );

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/conjurer/ContagiousFacadeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/conjurer/ContagiousFacadeBranch.java
@@ -50,7 +50,7 @@ public class ContagiousFacadeBranch extends AbstractUpgradeBranch<ContagiousFaca
                                 public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                                     modifier.setModifier(value);
                                 }
-                            }, ability.getDamageAbsorption().addAdditiveModifier("Upgrade Branch", 0), 2.5f
+                            }, ability.getDamageAbsorption().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade Branch", 0), 2.5f
                 )
                 .addTo(treeB);
 
@@ -64,7 +64,7 @@ public class ContagiousFacadeBranch extends AbstractUpgradeBranch<ContagiousFaca
                         """,
                 50000,
                 () -> {
-                    ability.getCooldown().addMultiplicativeModifierMult("Corrosive Facade", 0.8f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Corrosive Facade", 0.8f);
                 }
         );
         masterUpgrade2 = new Upgrade(
@@ -78,8 +78,8 @@ public class ContagiousFacadeBranch extends AbstractUpgradeBranch<ContagiousFaca
                         """,
                 50000,
                 () -> {
-                    ability.getCooldown().addMultiplicativeModifierMult("Polluting Guise", 0.8f);
-                    ability.getDamageAbsorption().addAdditiveModifier("Polluting Guise", 20f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Polluting Guise", 0.8f);
+                    ability.getDamageAbsorption().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Polluting Guise", 20f);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/conjurer/PoisonousHexBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/conjurer/PoisonousHexBranch.java
@@ -7,14 +7,6 @@ import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class PoisonousHexBranch extends AbstractUpgradeBranch<PoisonousHex> {
 
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable hexDamage = ability.getDamageValues().getHexDamage();
-        hexDamage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        hexDamage.max().addMultiplicativeModifierAdd("PvE", .3f);
-        ability.setMaxEnemiesHit(4);
-    }
-
     public PoisonousHexBranch(AbilityTree abilityTree, PoisonousHex ability) {
         super(abilityTree, ability);
 
@@ -36,7 +28,7 @@ public class PoisonousHexBranch extends AbstractUpgradeBranch<PoisonousHex> {
                     public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                         modifier.setModifier(value / 100);
                     }
-                            }, ability.getProjectileSpeed().addMultiplicativeModifierAdd("Upgrade Branch", 0), 50f, 4
+                            }, ability.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Upgrade Branch", 0), 50f, 4
                 )
                 .addTo(treeB);
 
@@ -49,7 +41,7 @@ public class PoisonousHexBranch extends AbstractUpgradeBranch<PoisonousHex> {
                         """,
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -5);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -5);
                     ability.setMaxEnemiesHit(200);
                 }
         );
@@ -65,12 +57,20 @@ public class PoisonousHexBranch extends AbstractUpgradeBranch<PoisonousHex> {
                 50000,
                 () -> {
                     Value.RangedValueCritable damage = ability.getDamageValues().getHexDamage();
-                    damage.min().addMultiplicativeModifierAdd("Master Upgrade Branch", .35f);
-                    damage.max().addMultiplicativeModifierAdd("Master Upgrade Branch", .35f);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", .35f);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", .35f);
                     ability.setMaxEnemiesHit(ability.getMaxEnemiesHit() + 12);
                     ability.setTicksBetweenDot(10);
                 }
         );
+    }
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable hexDamage = ability.getDamageValues().getHexDamage();
+        hexDamage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        hexDamage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        ability.setMaxEnemiesHit(4);
     }
 
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/conjurer/SoulfireBeamBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/conjurer/SoulfireBeamBranch.java
@@ -6,15 +6,9 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class SoulfireBeamBranch extends AbstractUpgradeBranch<SoulfireBeam> {
-
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable hexDamage = ability.getDamageValues().getBeamDamage();
-        hexDamage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        hexDamage.max().addMultiplicativeModifierAdd("PvE", .3f);
-    }
 
     public SoulfireBeamBranch(AbilityTree abilityTree, SoulfireBeam ability) {
         super(abilityTree, ability);
@@ -51,12 +45,19 @@ public class SoulfireBeamBranch extends AbstractUpgradeBranch<SoulfireBeam> {
                         """,
                 50000,
                 () -> {
-                    ability.getHitBoxRadius().addAdditiveModifier("Master Upgrade Branch", 3);
-                    ability.getMaxDistance().addAdditiveModifier("Master Upgrade Branch", 15);
+                    ability.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 3);
+                    ability.getMaxDistance().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 15);
                     ability.setShotsFiredAtATime(3);
                     ability.getDamageValues().getDamageMultipliers().replaceAll(aFloat -> aFloat * 2);
                 }
         );
+    }
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable hexDamage = ability.getDamageValues().getBeamDamage();
+        hexDamage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        hexDamage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
     }
 
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/luminary/EnergySeerBranchLuminary.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/luminary/EnergySeerBranchLuminary.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class EnergySeerBranchLuminary extends AbstractUpgradeBranch<EnergySeerLuminary> {
 
@@ -51,7 +52,7 @@ public class EnergySeerBranchLuminary extends AbstractUpgradeBranch<EnergySeerLu
                 () -> {
                     ability.setEpsDecrease(0);
                     ability.setTickDuration(ability.getTickDuration() + 100);
-                    ability.getCooldown().addMultiplicativeModifierMult("Benevolent Gaze", 0.8f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Benevolent Gaze", 0.8f);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/luminary/MercifulHexBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/luminary/MercifulHexBranch.java
@@ -6,6 +6,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class MercifulHexBranch extends AbstractUpgradeBranch<MercifulHex> {
 
@@ -36,13 +37,13 @@ public class MercifulHexBranch extends AbstractUpgradeBranch<MercifulHex> {
                         """,
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -5);
-                    ability.getProjectileSpeed().addMultiplicativeModifierAdd("Master Upgrade Branch", 2);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -5);
+                    ability.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 2);
                     ability.setHexStacksPerHit(ability.getHexStacksPerHit() + 1);
                     ability.setHexStacksPerHitAfter(ability.getHexStacksPerHitAfter() + 1);
                     Value.RangedValueCritable healing = ability.getHealValues().getHexHealing();
-                    healing.min().addAdditiveModifier("PvE", 100f);
-                    healing.max().addAdditiveModifier("PvE", 100f);
+                    healing.min().addModifier(FloatModifiable.ModifierType.ADDITIVE, "PvE", 100f);
+                    healing.max().addModifier(FloatModifiable.ModifierType.ADDITIVE, "PvE", 100f);
                 }
         );
         masterUpgrade2 = new Upgrade(
@@ -55,7 +56,7 @@ public class MercifulHexBranch extends AbstractUpgradeBranch<MercifulHex> {
                         """,
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -15);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -15);
                     ability.setTicksBetweenDot(10);
                 }
         );
@@ -66,12 +67,12 @@ public class MercifulHexBranch extends AbstractUpgradeBranch<MercifulHex> {
         ability.getDamageValues()
                .getValues()
                .forEach(value -> {
-                   value.forEachValue(floatModifiable -> floatModifiable.addMultiplicativeModifierAdd("PvE", .15f));
+                   value.forEachValue(floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .15f));
                });
         ability.getHealValues()
                .getValues()
                .forEach(value -> {
-                   value.forEachValue(floatModifiable -> floatModifiable.addMultiplicativeModifierAdd("PvE", .15f));
+                   value.forEachValue(floatModifiable -> floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .15f));
                });
         ability.setMaxAlliesHit(3);
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/luminary/RayOfLightBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/luminary/RayOfLightBranch.java
@@ -6,15 +6,9 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class RayOfLightBranch extends AbstractUpgradeBranch<RayOfLight> {
-
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable healing = ability.getHealValues().getRayHealing();
-        healing.min().addMultiplicativeModifierAdd("PvE", .3f);
-        healing.max().addMultiplicativeModifierAdd("PvE", .3f);
-    }
 
     public RayOfLightBranch(AbilityTree abilityTree, RayOfLight ability) {
         super(abilityTree, ability);
@@ -50,10 +44,17 @@ public class RayOfLightBranch extends AbstractUpgradeBranch<RayOfLight> {
                         """,
                 50000,
                 () -> {
-                    ability.getHealValues().getRayHealing().critMultiplier().addAdditiveModifier("Master Upgrade Branch", 45);
+                    ability.getHealValues().getRayHealing().critMultiplier().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 45);
                     ability.setShotsFiredAtATime(3);
                 }
         );
+    }
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable healing = ability.getHealValues().getRayHealing();
+        healing.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        healing.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
     }
 
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/luminary/SanctifiedBeaconBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/luminary/SanctifiedBeaconBranch.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class SanctifiedBeaconBranch extends AbstractUpgradeBranch<SanctifiedBeacon> {
 
@@ -32,7 +33,7 @@ public class SanctifiedBeaconBranch extends AbstractUpgradeBranch<SanctifiedBeac
                         """,
                 50000,
                 () -> {
-                    ability.getHitBoxRadius().addMultiplicativeModifierMult("Master Upgrade Branch", 2);
+                    ability.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Master Upgrade Branch", 2);
                     ability.setHexIntervalTicks((int) (ability.getHexIntervalTicks() * 0.5f));
                 }
         );
@@ -48,7 +49,7 @@ public class SanctifiedBeaconBranch extends AbstractUpgradeBranch<SanctifiedBeac
                         """,
                 50000,
                 () -> {
-                    ability.getHitBoxRadius().addMultiplicativeModifierMult("Master Upgrade Branch", 2);
+                    ability.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Master Upgrade Branch", 2);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/sentinel/EnergySeerBranchSentinel.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/sentinel/EnergySeerBranchSentinel.java
@@ -22,7 +22,8 @@ public class EnergySeerBranchSentinel extends AbstractUpgradeBranch<EnergySeerSe
                     public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                         modifier.setModifier(value / 100);
                     }
-                }, ability.getHealValues().getSeerHealingMultiplier().value().addAdditiveModifier("Upgrade Branch", 0), 25f)
+                            }, ability.getHealValues().getSeerHealingMultiplier().value().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade Branch", 0), 25f
+                )
                 .addTo(treeB);
 
         masterUpgrade = new Upgrade(
@@ -51,7 +52,7 @@ public class EnergySeerBranchSentinel extends AbstractUpgradeBranch<EnergySeerSe
                 () -> {
                     ability.setEpsDecrease(0);
                     ability.setTickDuration(ability.getTickDuration() + 120);
-                    ability.getCooldown().addMultiplicativeModifierMult("Collective Vaticinator", 0.75f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Collective Vaticinator", 0.75f);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/sentinel/FortifyingHexBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/sentinel/FortifyingHexBranch.java
@@ -7,15 +7,6 @@ import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class FortifyingHexBranch extends AbstractUpgradeBranch<FortifyingHex> {
 
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable damage = ability.getDamageValues().getHexDamage();
-        damage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .3f);
-        ability.setMaxEnemiesHit(2);
-        ability.setMaxAlliesHit(3);
-    }
-
     public FortifyingHexBranch(AbilityTree abilityTree, FortifyingHex ability) {
         super(abilityTree, ability);
 
@@ -32,7 +23,7 @@ public class FortifyingHexBranch extends AbstractUpgradeBranch<FortifyingHex> {
                     public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                         modifier.setModifier(value / 100);
                     }
-                            }, ability.getProjectileSpeed().addMultiplicativeModifierAdd("Upgrade Branch", 0), 50f, 4
+                            }, ability.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Upgrade Branch", 0), 50f, 4
                 )
                 .addTo(treeA);
 
@@ -54,8 +45,8 @@ public class FortifyingHexBranch extends AbstractUpgradeBranch<FortifyingHex> {
                 () -> {
                     ability.setMaxEnemiesHit(200);
                     ability.setMaxAlliesHit(200);
-                    ability.getEnergyCost().addAdditiveModifier("Bolstering Hex", -15);
-                    ability.getDamageReduction().addAdditiveModifier("Bolstering Hex", 3);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Bolstering Hex", -15);
+                    ability.getDamageReduction().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Bolstering Hex", 3);
                 }
         );
         masterUpgrade2 = new Upgrade(
@@ -69,6 +60,15 @@ public class FortifyingHexBranch extends AbstractUpgradeBranch<FortifyingHex> {
 
                 }
         );
+    }
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable damage = ability.getDamageValues().getHexDamage();
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        ability.setMaxEnemiesHit(2);
+        ability.setMaxAlliesHit(3);
     }
 
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/sentinel/GuardianBeamBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/sentinel/GuardianBeamBranch.java
@@ -10,14 +10,6 @@ import java.util.List;
 
 public class GuardianBeamBranch extends AbstractUpgradeBranch<GuardianBeam> {
 
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable damage = ability.getDamageValues().getBeamDamage();
-        damage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .3f);
-        ability.setShieldValues(new ArrayList<>(List.of(600, 1200, 2400)));
-    }
-
     public GuardianBeamBranch(AbilityTree abilityTree, GuardianBeam ability) {
         super(abilityTree, ability);
 
@@ -39,7 +31,7 @@ public class GuardianBeamBranch extends AbstractUpgradeBranch<GuardianBeam> {
                     public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                         modifier.setModifier(value);
                     }
-                            }, ability.getMaxDistance().addAdditiveModifier("Upgrade Branch", 0), 4
+                            }, ability.getMaxDistance().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade Branch", 0), 4
                 )
                 .addTo(treeB);
 
@@ -67,10 +59,18 @@ public class GuardianBeamBranch extends AbstractUpgradeBranch<GuardianBeam> {
                 50000,
                 () -> {
                     Value.RangedValueCritable damage = ability.getDamageValues().getBeamDamage();
-                    damage.min().addMultiplicativeModifierAdd("PvE", .25f);
-                    damage.max().addMultiplicativeModifierAdd("PvE", .25f);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .25f);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .25f);
                 }
         );
+    }
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable damage = ability.getDamageValues().getBeamDamage();
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        ability.setShieldValues(new ArrayList<>(List.of(600, 1200, 2400)));
     }
 
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/sentinel/MysticalBarrierBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/arcanist/sentinel/MysticalBarrierBranch.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class MysticalBarrierBranch extends AbstractUpgradeBranch<MysticalBarrier> {
 
@@ -32,7 +33,7 @@ public class MysticalBarrierBranch extends AbstractUpgradeBranch<MysticalBarrier
                         """,
                 50000,
                 () -> {
-                    ability.getCooldown().addMultiplicativeModifierMult("Transcendent Barrier", 0.8f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Transcendent Barrier", 0.8f);
                     ability.setShieldMaxHealth(ability.getShieldMaxHealth() + 3000);
                     ability.setShieldIncrease(ability.getShieldIncrease() + 80);
                     ability.setTickDuration(ability.getTickDuration() + 60);

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/mage/aquamancer/HealingRainBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/mage/aquamancer/HealingRainBranch.java
@@ -5,12 +5,13 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class HealingRainBranch extends AbstractUpgradeBranch<HealingRain> {
 
     @Override
     public void runOnce() {
-        ability.getCooldown().addAdditiveModifier("PVE", -6);
+        ability.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "PVE", -6);
     }
 
     public HealingRainBranch(AbilityTree abilityTree, HealingRain ability) {

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/mage/aquamancer/WaterBoltBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/mage/aquamancer/WaterBoltBranch.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class WaterBoltBranch extends AbstractUpgradeBranch<WaterBolt> {
 
@@ -29,8 +30,8 @@ public class WaterBoltBranch extends AbstractUpgradeBranch<WaterBolt> {
                 "+6 Energy per hit\n+100% Projectile speed\n\nWater Bolt increases the energy per hit of all allies it hits by +6 for 5 seconds.",
                 50000,
                 () -> {
-                    ability.getProjectileSpeed().addMultiplicativeModifierAdd("Master Upgrade Branch", 1);
-                    abilityTree.getWarlordsPlayer().getEnergyPerHit().addAdditiveModifier("Master Upgrade Branch", 6);
+                    ability.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 1);
+                    abilityTree.getWarlordsPlayer().getEnergyPerHit().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 6);
                 }
         );
         masterUpgrade2 = new Upgrade(
@@ -44,8 +45,8 @@ public class WaterBoltBranch extends AbstractUpgradeBranch<WaterBolt> {
                         """,
                 50000,
                 () -> {
-                    ability.getProjectileSpeed().addMultiplicativeModifierAdd("Master Upgrade Branch", 1);
-                    ability.getHealValues().getBoltHealing().critMultiplier().addAdditiveModifier("Master Upgrade Branch", 25);
+                    ability.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 1);
+                    ability.getHealValues().getBoltHealing().critMultiplier().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 25);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/mage/cryomancer/FreezingBreathBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/mage/cryomancer/FreezingBreathBranch.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.pve.upgrades.mage.cryomancer;
 import com.ebicep.warlords.abilities.FreezingBreath;
 import com.ebicep.warlords.abilities.internal.Value;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import javax.annotation.Nullable;
 
@@ -51,8 +52,8 @@ public class FreezingBreathBranch extends AbstractUpgradeBranch<FreezingBreath> 
                 50000,
                 () -> {
                     Value.RangedValueCritable damage = ability.getDamageValues().getFreezingBreathDamage();
-                    damage.min().addMultiplicativeModifierAdd("Master Upgrade Branch", .5f);
-                    damage.max().addMultiplicativeModifierAdd("Master Upgrade Branch", .5f);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", .5f);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", .5f);
                     ability.setHitbox(ability.getHitbox() * 1.6f);
                     ability.setMaxAnimationTime(ability.getMaxAnimationTime() * 2);
                 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/mage/cryomancer/FrostboltBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/mage/cryomancer/FrostboltBranch.java
@@ -22,7 +22,7 @@ public class FrostboltBranch extends AbstractUpgradeBranch<FrostBolt> {
                     public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                         modifier.setModifier(value / 100);
                     }
-                            }, ability.getProjectileSpeed().addMultiplicativeModifierAdd("Upgrade Branch", 0), 50f, 4
+                            }, ability.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Upgrade Branch", 0), 50f, 4
                 )
                 .addTo(treeA);
 
@@ -50,7 +50,7 @@ public class FrostboltBranch extends AbstractUpgradeBranch<FrostBolt> {
                         """,
                 50000,
                 () -> {
-                    ability.getSplashRadius().addAdditiveModifier("Master Upgrade Branch", 1.5f);
+                    ability.getSplashRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 1.5f);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/mage/pyromancer/FireballBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/mage/pyromancer/FireballBranch.java
@@ -22,7 +22,7 @@ public class FireballBranch extends AbstractUpgradeBranch<Fireball> {
                     public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                         modifier.setModifier(value / 100);
                     }
-                            }, ability.getProjectileSpeed().addMultiplicativeModifierAdd("Upgrade Branch", 0), 50f, 4
+                            }, ability.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Upgrade Branch", 0), 50f, 4
                 )
                 .addTo(treeA);
 

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/mage/pyromancer/FlameburstBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/mage/pyromancer/FlameburstBranch.java
@@ -30,7 +30,8 @@ public class FlameburstBranch extends AbstractUpgradeBranch<FlameBurst> {
                     public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                         modifier.setModifier(value);
                     }
-                }, ability.getDamageValues().getFlameBurstDamage().critMultiplier().addAdditiveModifier("Upgrade Branch", 0), 15f, 4)
+                            }, ability.getDamageValues().getFlameBurstDamage().critMultiplier().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade Branch", 0), 15f, 4
+                )
                 .addTo(treeB);
 
         masterUpgrade = new Upgrade(
@@ -41,11 +42,11 @@ public class FlameburstBranch extends AbstractUpgradeBranch<FlameBurst> {
                 50000,
                 () -> {
                     ability.setProjectileWidth(0.72D);
-                    ability.getProjectileSpeed().addMultiplicativeModifierMult("Master Upgrade Branch", .2f);
+                    ability.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Master Upgrade Branch", .2f);
                     Value.RangedValueCritable damage = ability.getDamageValues().getFlameBurstDamage();
-                    damage.min().addMultiplicativeModifierAdd("Master Upgrade Branch", 1f);
-                    damage.max().addMultiplicativeModifierAdd("Master Upgrade Branch", 1f);
-                    ability.getSplashRadius().addAdditiveModifier("Master Upgrade Branch", 5);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 1f);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 1f);
+                    ability.getSplashRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 5);
 
                 }
         );
@@ -58,7 +59,7 @@ public class FlameburstBranch extends AbstractUpgradeBranch<FlameBurst> {
                 50000,
                 () -> {
                     ability.getHitBoxRadius().setBaseValue(ability.getSplashRadius().getCalculatedValue()/2.5f);
-                    ability.getMaxDistance().addAdditiveModifier("Master Upgrade Branch", -132);
+                    ability.getMaxDistance().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -132);
                     ability.getSplashRadius().setBaseValue(0);
                 }
         );

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/AbstractConsecrateBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/AbstractConsecrateBranch.java
@@ -6,6 +6,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public abstract class AbstractConsecrateBranch<T extends AbstractConsecrate> extends AbstractUpgradeBranch<T> {
 
@@ -35,11 +36,11 @@ public abstract class AbstractConsecrateBranch<T extends AbstractConsecrate> ext
                 50000,
                 () -> {
                     Value.RangedValueCritable damage = ability.getConsecrateDamage();
-                    damage.min().addMultiplicativeModifierAdd("Master Upgrade Branch", 1.50f);
-                    damage.max().addMultiplicativeModifierAdd("Master Upgrade Branch", 1.50f);
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -30);
-                    ability.getHitBoxRadius().addAdditiveModifier("Master Upgrade Branch", 2);
-                    ability.getCooldown().addMultiplicativeModifierMult("Sanctify", 0.8f);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 1.50f);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 1.50f);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -30);
+                    ability.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 2);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Sanctify", 0.8f);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/avenger/AvengerStrikeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/avenger/AvengerStrikeBranch.java
@@ -80,7 +80,7 @@ public class AvengerStrikeBranch extends AbstractUpgradeBranch<AvengersStrike> {
 
                                 if (isAboveElite && event.getCause().equals("Avenger's Strike") && isNotDuplicateStrike) {
                                     currentDamageValue.addModifier(50, MultiFloatModifiable.ApplyFloatModifiableType.ADDITIVE, FloatModifiable.ModifierType.ADDITIVE,
-                                            "MAX HP DAMAGE (Avenger's Slash)", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.005f)
+                                            "Avenger's Slash", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.005f)
                                     );
                                 }
                             }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/avenger/AvengerStrikeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/avenger/AvengerStrikeBranch.java
@@ -14,6 +14,8 @@ import com.ebicep.warlords.player.ingame.motionsystem.MotionModifierBuilder;
 import com.ebicep.warlords.player.ingame.motionsystem.MotionSystem;
 import com.ebicep.warlords.pve.upgrades.*;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.MultiFloatModifiable;
 
 public class AvengerStrikeBranch extends AbstractUpgradeBranch<AvengersStrike> {
 
@@ -58,8 +60,8 @@ public class AvengerStrikeBranch extends AbstractUpgradeBranch<AvengersStrike> {
                         Deal 40% more damage against ADVANCED or lower enemies and deal 0.5% max health damage against ELITE or higher enemies.""",
                 50000,
                 () -> {
-                    ability.getHitBoxRadius().addAdditiveModifier("Master Upgrade Branch", 1);
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -5);
+                    ability.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 1);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -5);
 
                     warlordsPlayer.getCooldownManager().addCooldown(new PermanentCooldown<>(
                             "MAX HP DAMAGE (Avenger's Slash)",
@@ -77,7 +79,9 @@ public class AvengerStrikeBranch extends AbstractUpgradeBranch<AvengersStrike> {
                                                 !event.getFlags().contains(InstanceFlags.DUPLICATE_AVENGER_STRIKE);
 
                                 if (isAboveElite && event.getCause().equals("Avenger's Strike") && isNotDuplicateStrike) {
-                                    currentDamageValue.addAdditiveModifier("MAX HP DAMAGE (Avenger's Slash)", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.005f));
+                                    currentDamageValue.addModifier(50, MultiFloatModifiable.ApplyFloatModifiableType.ADDITIVE, FloatModifiable.ModifierType.ADDITIVE,
+                                            "MAX HP DAMAGE (Avenger's Slash)", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.005f)
+                                    );
                                 }
                             }
                     ));
@@ -97,8 +101,8 @@ public class AvengerStrikeBranch extends AbstractUpgradeBranch<AvengersStrike> {
                         """,
                 50000,
                 () -> {
-                    ability.getHitBoxRadius().addAdditiveModifier("Master Upgrade Branch", 1);
-                    ability.getDamageValues().getStrikeDamage().critChance().addAdditiveModifier("Master Upgrade Branch", 15);
+                    ability.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 1);
+                    ability.getDamageValues().getStrikeDamage().critChance().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 15);
                     MotionSystem calculateSpeed = warlordsPlayer.getSpeed();
                     MotionModifier modifier = new MotionModifierBuilder().setFrom(warlordsPlayer)
                                                                          .setName("Avenging Strike")
@@ -138,8 +142,8 @@ public class AvengerStrikeBranch extends AbstractUpgradeBranch<AvengersStrike> {
     @Override
     public void runOnce() {
         Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
-        damage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .3f);
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
     }
 
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/avenger/AvengersWrathBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/avenger/AvengersWrathBranch.java
@@ -2,6 +2,7 @@ package com.ebicep.warlords.pve.upgrades.paladin.avenger;
 
 import com.ebicep.warlords.abilities.AvengersWrath;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class AvengersWrathBranch extends AbstractUpgradeBranch<AvengersWrath> {
 
@@ -43,7 +44,7 @@ public class AvengersWrathBranch extends AbstractUpgradeBranch<AvengersWrath> {
                 () -> {
                     ability.setHitRadius(ability.getHitRadius() * 2);
                     ability.setMaxTargets(ability.getMaxTargets() + 3);
-                    ability.getCooldown().addMultiplicativeModifierMult("Avenger's Armageddon", 0.8f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Avenger's Armageddon", 0.8f);
                 }
         );
         masterUpgrade2 = new Upgrade(
@@ -56,7 +57,7 @@ public class AvengersWrathBranch extends AbstractUpgradeBranch<AvengersWrath> {
                         """,
                 50000,
                 () -> {
-                    ability.getCooldown().addMultiplicativeModifierMult("Avenger's Vexation", 0.8f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Avenger's Vexation", 0.8f);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/crusader/CrusadersStrikeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/crusader/CrusadersStrikeBranch.java
@@ -3,17 +3,11 @@ package com.ebicep.warlords.pve.upgrades.paladin.crusader;
 import com.ebicep.warlords.abilities.CrusadersStrike;
 import com.ebicep.warlords.abilities.internal.Value;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class CrusadersStrikeBranch extends AbstractUpgradeBranch<CrusadersStrike> {
 
     int energyGiven = ability.getEnergyGiven();
-
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
-        damage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .3f);
-    }
 
     public CrusadersStrikeBranch(AbilityTree abilityTree, CrusadersStrike ability) {
         super(abilityTree, ability);
@@ -64,9 +58,16 @@ public class CrusadersStrikeBranch extends AbstractUpgradeBranch<CrusadersStrike
                         """,
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -10);
-                    ability.getDamageValues().getStrikeDamage().critChance().addAdditiveModifier("Master Upgrade Branch", 5);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -10);
+                    ability.getDamageValues().getStrikeDamage().critChance().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 5);
                 }
         );
+    }
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
     }
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/crusader/InspiringPresenceBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/crusader/InspiringPresenceBranch.java
@@ -2,6 +2,7 @@ package com.ebicep.warlords.pve.upgrades.paladin.crusader;
 
 import com.ebicep.warlords.abilities.InspiringPresence;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class InspiringPresenceBranch extends AbstractUpgradeBranch<InspiringPresence> {
 
@@ -42,7 +43,7 @@ public class InspiringPresenceBranch extends AbstractUpgradeBranch<InspiringPres
                         """,
                 50000,
                 () -> {
-                    ability.getCooldown().addMultiplicativeModifierMult("Transcendent Presence", 0.9f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Transcendent Presence", 0.9f);
                 }
         );
         masterUpgrade2 = new Upgrade(
@@ -57,7 +58,7 @@ public class InspiringPresenceBranch extends AbstractUpgradeBranch<InspiringPres
                         """,
                 50000,
                 () -> {
-                    ability.getCooldown().addMultiplicativeModifierMult("Resilient Presence", 0.8f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Resilient Presence", 0.8f);
                     ability.setSpeedBuff(ability.getSpeedBuff() + 25);
                     abilityTree.getWarlordsPlayer().getSpec().setDamageResistance(abilityTree.getWarlordsPlayer().getSpec().getDamageResistance() + 10);
                 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/protector/HammerOfLightBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/protector/HammerOfLightBranch.java
@@ -2,6 +2,7 @@ package com.ebicep.warlords.pve.upgrades.paladin.protector;
 
 import com.ebicep.warlords.abilities.HammerOfLight;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class HammerOfLightBranch extends AbstractUpgradeBranch<HammerOfLight> {
 
@@ -50,8 +51,8 @@ public class HammerOfLightBranch extends AbstractUpgradeBranch<HammerOfLight> {
                         """,
                 50000,
                 () -> {
-                    ability.getCooldown().addMultiplicativeModifierMult("Master Upgrade Branch", 0.8f);
-                    ability.getHammerRadius().addAdditiveModifier("Master Upgrade Branch", 5);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Master Upgrade Branch", 0.8f);
+                    ability.getHammerRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 5);
                     ability.setCrownEnergyReduction(ability.getCrownEnergyReduction() + 15);
                 }
         );

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/protector/HolyRadianceBranchProtector.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/protector/HolyRadianceBranchProtector.java
@@ -2,6 +2,7 @@ package com.ebicep.warlords.pve.upgrades.paladin.protector;
 
 import com.ebicep.warlords.abilities.HolyRadianceProtector;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class HolyRadianceBranchProtector extends AbstractUpgradeBranch<HolyRadianceProtector> {
 
@@ -51,7 +52,7 @@ public class HolyRadianceBranchProtector extends AbstractUpgradeBranch<HolyRadia
                         """,
                 50000,
                 () -> {
-                    ability.getMarkRadius().addAdditiveModifier("Master Upgrade Branch", 12);
+                    ability.getMarkRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 12);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/protector/ProtectorStrikeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/paladin/protector/ProtectorStrikeBranch.java
@@ -6,15 +6,9 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class ProtectorStrikeBranch extends AbstractUpgradeBranch<ProtectorsStrike> {
-
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
-        damage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .3f);
-    }
 
     public ProtectorStrikeBranch(AbilityTree abilityTree, ProtectorsStrike ability) {
         super(abilityTree, ability);
@@ -49,12 +43,19 @@ public class ProtectorStrikeBranch extends AbstractUpgradeBranch<ProtectorsStrik
                 50000,
                 () -> {
                     Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
-                    damage.min().addMultiplicativeModifierAdd("Master Upgrade Branch", .2f);
-                    damage.max().addMultiplicativeModifierAdd("Master Upgrade Branch", .2f);
-                    ability.getDamageValues().getStrikeDamage().critChance().addAdditiveModifier("Master Upgrade Branch", 15);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", .2f);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", .2f);
+                    ability.getDamageValues().getStrikeDamage().critChance().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 15);
                     ability.setStrikeRadius(ability.getStrikeRadius() * 2);
                     ability.setMaxAllies(ability.getMaxAllies() + 1);
                 }
         );
+    }
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
     }
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/apothecary/DrainingMiasmaBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/apothecary/DrainingMiasmaBranch.java
@@ -6,6 +6,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class DrainingMiasmaBranch extends AbstractUpgradeBranch<DrainingMiasma> {
 
@@ -36,7 +37,7 @@ public class DrainingMiasmaBranch extends AbstractUpgradeBranch<DrainingMiasma> 
 
                     ability.setMaxHealthDamage((int) (ability.getMaxHealthDamage() * 0.25f));
                     Value.SetValue damage = ability.getDamageValues().getMiasmaDamage();
-                    damage.value().addMultiplicativeModifierAdd("Master Upgrade Branch", -.75f);
+                    damage.value().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", -.75f);
                 }
         );
         masterUpgrade2 = new Upgrade(
@@ -54,7 +55,7 @@ public class DrainingMiasmaBranch extends AbstractUpgradeBranch<DrainingMiasma> 
 
                     ability.setMaxHealthDamage((int) (ability.getMaxHealthDamage() * 0.5f));
                     Value.SetValue damage = ability.getDamageValues().getMiasmaDamage();
-                    damage.value().addMultiplicativeModifierAdd("Master Upgrade Branch", -.5f);
+                    damage.value().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", -.5f);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/apothecary/ImpalingStrikeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/apothecary/ImpalingStrikeBranch.java
@@ -3,18 +3,9 @@ package com.ebicep.warlords.pve.upgrades.rogue.apothecary;
 import com.ebicep.warlords.abilities.ImpalingStrike;
 import com.ebicep.warlords.abilities.internal.Value;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class ImpalingStrikeBranch extends AbstractUpgradeBranch<ImpalingStrike> {
-
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
-        damage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .3f);
-        ability.setLeechAmount(14);
-    }
-
-    float leechAmount = ability.getLeechAmount();
 
     public ImpalingStrikeBranch(AbilityTree abilityTree, ImpalingStrike ability) {
         super(abilityTree, ability);
@@ -49,7 +40,7 @@ public class ImpalingStrikeBranch extends AbstractUpgradeBranch<ImpalingStrike> 
                         Your Impaling strikes now hit 2 additional targets and triple the damage to enemies afflicted by LEECH""",
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -10);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -10);
                 }
         );
         masterUpgrade2 = new Upgrade(
@@ -62,8 +53,18 @@ public class ImpalingStrikeBranch extends AbstractUpgradeBranch<ImpalingStrike> 
                         """,
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -20);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -20);
                 }
         );
+    }
+
+    float leechAmount = ability.getLeechAmount();
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        ability.setLeechAmount(14);
     }
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/apothecary/RemedicChainsBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/apothecary/RemedicChainsBranch.java
@@ -5,13 +5,9 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class RemedicChainsBranch extends AbstractUpgradeBranch<RemedicChains> {
-
-    @Override
-    public void runOnce() {
-        ability.getDamageValues().getBonusDamage().value().addAdditiveModifier("PvE (Base)", 80);
-    }
 
     public RemedicChainsBranch(AbilityTree abilityTree, RemedicChains ability) {
         super(abilityTree, ability);
@@ -36,7 +32,7 @@ public class RemedicChainsBranch extends AbstractUpgradeBranch<RemedicChains> {
                 50000,
                 () -> {
                     ability.setLinkBreakRadius(ability.getLinkBreakRadius() + 20);
-                    ability.getDamageValues().getBonusDamage().value().addAdditiveModifier("Crystallizing Chains", 80);
+                    ability.getDamageValues().getBonusDamage().value().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Crystallizing Chains", 80);
                 }
         );
         masterUpgrade2 = new Upgrade(
@@ -52,5 +48,10 @@ public class RemedicChainsBranch extends AbstractUpgradeBranch<RemedicChains> {
                     ability.setLinkBreakRadius(ability.getLinkBreakRadius() + 20);
                 }
         );
+    }
+
+    @Override
+    public void runOnce() {
+        ability.getDamageValues().getBonusDamage().value().addModifier(FloatModifiable.ModifierType.ADDITIVE, "PvE (Base)", 80);
     }
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/assassin/IncendiaryCurseBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/assassin/IncendiaryCurseBranch.java
@@ -6,17 +6,9 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class IncendiaryCurseBranch extends AbstractUpgradeBranch<IncendiaryCurse> {
-
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable damage = ability.getDamageValues().getCurseDamage();
-        ability.getEnergyCost().setBaseValue(40);
-        ability.setBlindDurationInTicks(30);
-        damage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .3f);
-    }
 
     public IncendiaryCurseBranch(AbilityTree abilityTree, IncendiaryCurse ability) {
         super(abilityTree, ability);
@@ -51,12 +43,21 @@ public class IncendiaryCurseBranch extends AbstractUpgradeBranch<IncendiaryCurse
                         """,
                 50000,
                 () -> {
-                    ability.getHitBoxRadius().addAdditiveModifier("Master Upgrade", 3);
+                    ability.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade", 3);
 
                     Value.RangedValueCritable damage = ability.getDamageValues().getCurseDamage();
-                    damage.min().addMultiplicativeModifierAdd("PvE", .3f);
-                    damage.max().addMultiplicativeModifierAdd("PvE", .3f);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
                 }
         );
+    }
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable damage = ability.getDamageValues().getCurseDamage();
+        ability.getEnergyCost().setBaseValue(40);
+        ability.setBlindDurationInTicks(30);
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
     }
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/assassin/JudgementStrikeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/assassin/JudgementStrikeBranch.java
@@ -73,7 +73,7 @@ public class JudgementStrikeBranch extends AbstractUpgradeBranch<JudgementStrike
                     ).addModifier(Modifier.MODIFY_OUTGOING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                                 if (event.getCause().equals("Judgement Strike")) {
                                     currentDamageValue.addModifier(50, MultiFloatModifiable.ApplyFloatModifiableType.ADDITIVE, FloatModifiable.ModifierType.ADDITIVE,
-                                            "MAX HP DAMAGE (Death Strike)", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.01f)
+                                            "Death Strike", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.01f)
                                     );
                                 }
                             }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/assassin/JudgementStrikeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/assassin/JudgementStrikeBranch.java
@@ -8,6 +8,7 @@ import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.upgrades.*;
 import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.MultiFloatModifiable;
 
 public class JudgementStrikeBranch extends AbstractUpgradeBranch<JudgementStrike> {
 
@@ -33,7 +34,7 @@ public class JudgementStrikeBranch extends AbstractUpgradeBranch<JudgementStrike
                                 public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                                     modifier.setModifier(value);
                                 }
-                            }, ability.getHealValues().getStrikeHealing().value().addAdditiveModifier("Upgrade Branch", 0), 100f
+                            }, ability.getHealValues().getStrikeHealing().value().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade Branch", 0), 100f
                 )
                 .addUpgradeEnergy(ability, 5f)
                 .addTo(treeB);
@@ -50,10 +51,14 @@ public class JudgementStrikeBranch extends AbstractUpgradeBranch<JudgementStrike
                         """,
                 50000,
                 () -> {
-                    ability.getDamageValues().getStrikeDamage().min().addMultiplicativeModifierAdd("Master Upgrade Branch", .15f);
-                    ability.getDamageValues().getStrikeDamage().max().addMultiplicativeModifierAdd("Master Upgrade Branch", .15f);
-                    ability.getHealValues().getStrikeHealing().value().addAdditiveModifier("Master Upgrade Branch", 100);
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -10);
+                    ability.getDamageValues().getStrikeDamage().min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                            "Master Upgrade Branch", .15f
+                    );
+                    ability.getDamageValues().getStrikeDamage().max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                            "Master Upgrade Branch", .15f
+                    );
+                    ability.getHealValues().getStrikeHealing().value().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 100);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -10);
                     ability.setStrikeCritInterval(2);
 
                     abilityTree.getWarlordsPlayer().getCooldownManager().addCooldown(new PermanentCooldown<>(
@@ -67,7 +72,9 @@ public class JudgementStrikeBranch extends AbstractUpgradeBranch<JudgementStrike
                             false
                     ).addModifier(Modifier.MODIFY_OUTGOING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                                 if (event.getCause().equals("Judgement Strike")) {
-                                    currentDamageValue.addAdditiveModifier("MAX HP DAMAGE (Death Strike)", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.01f));
+                                    currentDamageValue.addModifier(50, MultiFloatModifiable.ApplyFloatModifiableType.ADDITIVE, FloatModifiable.ModifierType.ADDITIVE,
+                                            "MAX HP DAMAGE (Death Strike)", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.01f)
+                                    );
                                 }
                             }
                     ));
@@ -83,7 +90,7 @@ public class JudgementStrikeBranch extends AbstractUpgradeBranch<JudgementStrike
                         """,
                 50000,
                 () -> {
-                    ability.getDamageValues().getStrikeDamage().critMultiplier().addAdditiveModifier("Master Upgrade Branch", 30);
+                    ability.getDamageValues().getStrikeDamage().critMultiplier().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 30);
                 }
         );
     }
@@ -91,8 +98,8 @@ public class JudgementStrikeBranch extends AbstractUpgradeBranch<JudgementStrike
     @Override
     public void runOnce() {
         Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
-        damage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .3f);
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
         ability.setDamageIncreaseHealthThreshold(ability.getDamageIncreaseHealthThreshold() + 30);
     }
 

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/assassin/ShadowStepBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/assassin/ShadowStepBranch.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class ShadowStepBranch extends AbstractUpgradeBranch<ShadowStep> {
 
@@ -43,7 +44,7 @@ public class ShadowStepBranch extends AbstractUpgradeBranch<ShadowStep> {
                         """,
                 50000,
                 () -> {
-                    ability.getCooldown().addMultiplicativeModifierMult("Shadow Dash", 0.9f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Shadow Dash", 0.9f);
                     ability.setMaxCharges(2);
                 }
         );

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/vindicator/HeartToHeartBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/vindicator/HeartToHeartBranch.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class HeartToHeartBranch extends AbstractUpgradeBranch<HeartToHeart> {
 
@@ -40,7 +41,7 @@ public class HeartToHeartBranch extends AbstractUpgradeBranch<HeartToHeart> {
                         """,
                 50000,
                 () -> {
-                    ability.getHitBoxRadius().addAdditiveModifier("Master Upgrade Branch", 10);
+                    ability.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 10);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/vindicator/PrismGuardBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/vindicator/PrismGuardBranch.java
@@ -29,7 +29,8 @@ public class PrismGuardBranch extends AbstractUpgradeBranch<PrismGuard> {
                     public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                         modifier.setModifier(value);
                     }
-                }, ability.getHealValues().getBubbleBaseHealing().value().addAdditiveModifier("Upgrade Branch", 0), 100f)
+                            }, ability.getHealValues().getBubbleBaseHealing().value().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade Branch", 0), 100f
+                )
                 .addUpgrade(new UpgradeTypes.HealingUpgradeType() {
 
                     @Override
@@ -41,7 +42,8 @@ public class PrismGuardBranch extends AbstractUpgradeBranch<PrismGuard> {
                     public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                         modifier.setModifier(value);
                     }
-                }, ability.getHealValues().getBubbleMissingHealthHealing().value().addAdditiveModifier("Upgrade Branch", 0), 1f)
+                            }, ability.getHealValues().getBubbleMissingHealthHealing().value().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade Branch", 0), 1f
+                )
                 .addTo(treeA);
 
         UpgradeTreeBuilder

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/vindicator/RighteousStrikeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/rogue/vindicator/RighteousStrikeBranch.java
@@ -6,16 +6,10 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class RighteousStrikeBranch extends AbstractUpgradeBranch<RighteousStrike> {
 
-
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
-        damage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .3f);
-    }
 
     public RighteousStrikeBranch(AbilityTree abilityTree, RighteousStrike ability) {
         super(abilityTree, ability);
@@ -48,8 +42,15 @@ public class RighteousStrikeBranch extends AbstractUpgradeBranch<RighteousStrike
                         """,
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Righteous Strike Master", -10f);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Righteous Strike Master", -10f);
                 }
         );
+    }
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
     }
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/earthwarden/BoulderBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/earthwarden/BoulderBranch.java
@@ -6,6 +6,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class BoulderBranch extends AbstractUpgradeBranch<Boulder> {
 
@@ -31,10 +32,10 @@ public class BoulderBranch extends AbstractUpgradeBranch<Boulder> {
                 50000,
                 () -> {
                     ability.setBoulderSpeed(ability.getBoulderSpeed() * 0.25f);
-                    ability.getCooldown().addMultiplicativeModifierMult("Terrestrial Meteor", 2);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Terrestrial Meteor", 2);
                     Value.RangedValueCritable damage = ability.getDamageValues().getBoulderDamage();
-                    damage.min().addMultiplicativeModifierAdd("Master Upgrade Branch", 3);
-                    damage.max().addMultiplicativeModifierAdd("Master Upgrade Branch", 3);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 3);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 3);
                     ability.setHitbox(hitbox + 3);
                 }
         );
@@ -47,8 +48,8 @@ public class BoulderBranch extends AbstractUpgradeBranch<Boulder> {
                 50000,
                 () -> {
                     Value.RangedValueCritable damage = ability.getDamageValues().getBoulderDamage();
-                    damage.min().addMultiplicativeModifierAdd("Master Upgrade Branch", 2);
-                    damage.max().addMultiplicativeModifierAdd("Master Upgrade Branch", 2);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 2);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 2);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/earthwarden/EarthenSpikeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/earthwarden/EarthenSpikeBranch.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.pve.upgrades.shaman.earthwarden;
 import com.ebicep.warlords.abilities.EarthenSpike;
 import com.ebicep.warlords.abilities.internal.Value;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class EarthenSpikeBranch extends AbstractUpgradeBranch<EarthenSpike> {
 
@@ -57,8 +58,8 @@ public class EarthenSpikeBranch extends AbstractUpgradeBranch<EarthenSpike> {
                 50000,
                 () -> {
                     Value.RangedValueCritable damage = ability.getDamageValues().getSpikeDamage();
-                    damage.min().addMultiplicativeModifierAdd("Master Upgrade Branch", 2);
-                    damage.max().addMultiplicativeModifierAdd("Master Upgrade Branch", 2);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 2);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 2);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/spiritguard/FallenSoulsBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/spiritguard/FallenSoulsBranch.java
@@ -5,12 +5,13 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class FallenSoulsBranch extends AbstractUpgradeBranch<FallenSouls> {
 
     @Override
     public void runOnce() {
-        abilityTree.getWarlordsPlayer().getHealth().addAdditiveModifier("PvE (Base)", 300);
+        abilityTree.getWarlordsPlayer().getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "PvE (Base)", 300);
     }
 
     public FallenSoulsBranch(AbilityTree abilityTree, FallenSouls ability) {

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/spiritguard/SpiritLinkBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/spiritguard/SpiritLinkBranch.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.pve.upgrades.shaman.spiritguard;
 import com.ebicep.warlords.abilities.SpiritLink;
 import com.ebicep.warlords.abilities.internal.Value;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.jetbrains.annotations.Nullable;
 
 public class SpiritLinkBranch extends AbstractUpgradeBranch<SpiritLink> {
@@ -12,8 +13,8 @@ public class SpiritLinkBranch extends AbstractUpgradeBranch<SpiritLink> {
     @Override
     public void runOnce() {
         Value.RangedValueCritable damage = ability.getDamageValues().getLinkDamage();
-        damage.min().addMultiplicativeModifierAdd("PvE", .2f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .2f);
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .2f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .2f);
     }
 
     public SpiritLinkBranch(AbilityTree abilityTree, SpiritLink ability) {

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/CapacitorTotemBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/CapacitorTotemBranch.java
@@ -6,6 +6,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class CapacitorTotemBranch extends AbstractUpgradeBranch<CapacitorTotem> {
 
@@ -30,8 +31,8 @@ public class CapacitorTotemBranch extends AbstractUpgradeBranch<CapacitorTotem> 
                 50000,
                 () -> {
                     Value.RangedValueCritable damage = ability.getDamageValues().getTotemDamage();
-                    damage.min().addMultiplicativeModifierAdd("Master Branch Upgrade", .2f);
-                    damage.max().addMultiplicativeModifierAdd("Master Branch Upgrade", .2f);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Branch Upgrade", .2f);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Branch Upgrade", .2f);
                 }
         );
         masterUpgrade2 = new Upgrade(

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/ChainLightningBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/ChainLightningBranch.java
@@ -2,6 +2,7 @@ package com.ebicep.warlords.pve.upgrades.shaman.thunderlord;
 
 import com.ebicep.warlords.abilities.ChainLightning;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class ChainLightningBranch extends AbstractUpgradeBranch<ChainLightning> {
 
@@ -53,7 +54,7 @@ public class ChainLightningBranch extends AbstractUpgradeBranch<ChainLightning> 
                         Chain Lightning now deals 10% more damage per bounce instead of less.""",
                 50000,
                 () -> {
-                    ability.getDamageDecreasePerBounce().addMultiplicativeModifierMult("Master Upgrade Branch", -1);
+                    ability.getDamageDecreasePerBounce().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Master Upgrade Branch", -1);
                     ability.setAdditionalBounces(ability.getAdditionalBounces() * 3);
                 }
         );

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/LightningBoltBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/LightningBoltBranch.java
@@ -27,7 +27,7 @@ public class LightningBoltBranch extends AbstractUpgradeBranch<LightningBolt> {
                         modifier.setModifier(value / 100);
                     }},
 
-                    ability.getProjectileSpeed().addMultiplicativeModifierAdd("Upgrade Branch", 0), 20f
+                        ability.getProjectileSpeed().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Upgrade Branch", 0), 20f
                 )
                 .addTo(treeA);
 
@@ -46,7 +46,7 @@ public class LightningBoltBranch extends AbstractUpgradeBranch<LightningBolt> {
                         Lightning Bolt shoots two additional projectiles.""",
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -10);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -10);
                     ability.setShotsFiredAtATime(3);
                 }
         );
@@ -60,7 +60,7 @@ public class LightningBoltBranch extends AbstractUpgradeBranch<LightningBolt> {
                         """,
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", 10);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 10);
                 }
         );
     }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/LightningRodBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/LightningRodBranch.java
@@ -34,7 +34,8 @@ public class LightningRodBranch extends AbstractUpgradeBranch<LightningRod> {
                     public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                         modifier.setModifier(value);
                     }
-                }, ability.getHealValues().getHealthRestore().value().addAdditiveModifier("Upgrade Branch", 0), 6f)
+                            }, ability.getHealValues().getHealthRestore().value().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade Branch", 0), 6f
+                )
                 .addTo(treeB);
 
         masterUpgrade = new Upgrade(

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/WindfuryBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/WindfuryBranch.java
@@ -6,6 +6,8 @@ import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
 import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.MultiFloatModifiable;
 
 public class WindfuryBranch extends AbstractUpgradeBranch<WindfuryWeapon> {
 
@@ -130,7 +132,9 @@ public class WindfuryBranch extends AbstractUpgradeBranch<WindfuryWeapon> {
                             false
                     ).addModifier(Modifier.MODIFY_OUTGOING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                                 if (event.getCause().equals("Windfury Weapon")) {
-                                    currentDamageValue.addAdditiveModifier("MAX HP DAMAGE (Shredding Fury)", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.005f));
+                                    currentDamageValue.addModifier(50, MultiFloatModifiable.ApplyFloatModifiableType.ADDITIVE, FloatModifiable.ModifierType.ADDITIVE,
+                                            "MAX HP DAMAGE (Shredding Fury)", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.005f)
+                                    );
                                 }
                             }
                     ));

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/WindfuryBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/shaman/thunderlord/WindfuryBranch.java
@@ -133,7 +133,7 @@ public class WindfuryBranch extends AbstractUpgradeBranch<WindfuryWeapon> {
                     ).addModifier(Modifier.MODIFY_OUTGOING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                                 if (event.getCause().equals("Windfury Weapon")) {
                                     currentDamageValue.addModifier(50, MultiFloatModifiable.ApplyFloatModifiableType.ADDITIVE, FloatModifiable.ModifierType.ADDITIVE,
-                                            "MAX HP DAMAGE (Shredding Fury)", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.005f)
+                                            "Shredding Fury", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.005f)
                                     );
                                 }
                             }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/berserker/WoundingStrikeBranchBerserker.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/berserker/WoundingStrikeBranchBerserker.java
@@ -8,13 +8,6 @@ import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class WoundingStrikeBranchBerserker extends AbstractUpgradeBranch<WoundingStrikeBerserker> {
 
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
-        damage.min().addMultiplicativeModifierAdd("PvE", .5f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .5f);
-    }
-
     public WoundingStrikeBranchBerserker(AbilityTree abilityTree, WoundingStrikeBerserker ability) {
         super(abilityTree, ability);
 
@@ -37,7 +30,7 @@ public class WoundingStrikeBranchBerserker extends AbstractUpgradeBranch<Woundin
                     public void modifyFloatModifiable(FloatModifiable.FloatModifier modifier, float value) {
                         modifier.setModifier(value);
                     }
-                            }, ability.getWounding().addAdditiveModifier("Upgrade Branch", 0), 2f
+                            }, ability.getWounding().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Upgrade Branch", 0), 2f
                 )
                 .addTo(treeB);
 
@@ -53,10 +46,10 @@ public class WoundingStrikeBranchBerserker extends AbstractUpgradeBranch<Woundin
                         BLEED: Enemies afflicted take 100% more damage from Wounding Strike while Blood Lust is active. Bleeding enemies have their healing reduced by 80% and lose 0.5% of their max health per second.""",
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -5);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -5);
                     Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
-                    damage.min().addMultiplicativeModifierAdd("Master Upgrade Branch", .5f);
-                    damage.max().addMultiplicativeModifierAdd("Master Upgrade Branch", .5f);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", .5f);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", .5f);
                 }
         );
         masterUpgrade2 = new Upgrade(
@@ -69,12 +62,19 @@ public class WoundingStrikeBranchBerserker extends AbstractUpgradeBranch<Woundin
                         """,
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -10);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -10);
                     abilityTree.getWarlordsPlayer().doOnStaticAbility(BloodLust.class, bloodLust -> {
                         bloodLust.setDamageConvertPercent(bloodLust.getDamageConvertPercent() - 25);
                     });
                 }
         );
 
+    }
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .5f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .5f);
     }
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/defender/LastStandBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/defender/LastStandBranch.java
@@ -2,6 +2,7 @@ package com.ebicep.warlords.pve.upgrades.warrior.defender;
 
 import com.ebicep.warlords.abilities.LastStand;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 import javax.annotation.Nonnull;
 
@@ -52,7 +53,7 @@ public class LastStandBranch extends AbstractUpgradeBranch<LastStand> {
                         """,
                 50000,
                 () -> {
-                    ability.getCooldown().addMultiplicativeModifierMult("Final Stand", 0.75f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Final Stand", 0.75f);
                     ability.setSelfDamageReductionPercent(ability.getSelfDamageReduction() + 25);
                     ability.setRadius(ability.getRadius() * 2);
                 }
@@ -68,7 +69,7 @@ public class LastStandBranch extends AbstractUpgradeBranch<LastStand> {
                         """,
                 50000,
                 () -> {
-                    ability.getCooldown().addMultiplicativeModifierMult("Enduring Defense", 0.75f);
+                    ability.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Enduring Defense", 0.75f);
                     ability.setTeammateDamageReductionPercent(ability.getTeammateDamageReduction() + 15);
                     ability.setRadius(ability.getRadius() * 2);
                 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/defender/WoundingStrikeBranchDefender.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/defender/WoundingStrikeBranchDefender.java
@@ -6,15 +6,9 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class WoundingStrikeBranchDefender extends AbstractUpgradeBranch<WoundingStrikeDefender> {
-
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
-        damage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .3f);
-    }
 
     public WoundingStrikeBranchDefender(AbilityTree abilityTree, WoundingStrikeDefender ability) {
         super(abilityTree, ability);
@@ -38,7 +32,7 @@ public class WoundingStrikeBranchDefender extends AbstractUpgradeBranch<Wounding
                         Critical Strikes grant you and nearby allies 30% damage reduction for 5 seconds.""",
                 50000,
                 () -> {
-                    ability.getDamageValues().getStrikeDamage().critChance().addAdditiveModifier("Master Upgrade Branch", 100);
+                    ability.getDamageValues().getStrikeDamage().critChance().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", 100);
                 }
         );
         masterUpgrade2 = new Upgrade(
@@ -51,8 +45,15 @@ public class WoundingStrikeBranchDefender extends AbstractUpgradeBranch<Wounding
                         """,
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -10);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -10);
                 }
         );
+    }
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
     }
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/revenant/CripplingStrikeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/revenant/CripplingStrikeBranch.java
@@ -6,16 +6,10 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class CripplingStrikeBranch extends AbstractUpgradeBranch<CripplingStrike> {
 
-
-    @Override
-    public void runOnce() {
-        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
-        damage.min().addMultiplicativeModifierAdd("PvE", .3f);
-        damage.max().addMultiplicativeModifierAdd("PvE", .3f);
-    }
 
     public CripplingStrikeBranch(AbilityTree abilityTree, CripplingStrike ability) {
         super(abilityTree, ability);
@@ -39,7 +33,7 @@ public class CripplingStrikeBranch extends AbstractUpgradeBranch<CripplingStrike
                         """,
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -10);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -10);
                     ability.setCripple(40);
                 }
         );
@@ -53,8 +47,15 @@ public class CripplingStrikeBranch extends AbstractUpgradeBranch<CripplingStrike
                         """,
                 50000,
                 () -> {
-                    ability.getEnergyCost().addAdditiveModifier("Master Upgrade Branch", -20);
+                    ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Master Upgrade Branch", -20);
                 }
         );
+    }
+
+    @Override
+    public void runOnce() {
+        Value.RangedValueCritable damage = ability.getDamageValues().getStrikeDamage();
+        damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
+        damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "PvE", .3f);
     }
 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/revenant/OrbsOfLifeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/revenant/OrbsOfLifeBranch.java
@@ -5,6 +5,7 @@ import com.ebicep.warlords.pve.upgrades.AbilityTree;
 import com.ebicep.warlords.pve.upgrades.AbstractUpgradeBranch;
 import com.ebicep.warlords.pve.upgrades.Upgrade;
 import com.ebicep.warlords.pve.upgrades.UpgradeTreeBuilder;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class OrbsOfLifeBranch extends AbstractUpgradeBranch<OrbsOfLife> {
 
@@ -31,7 +32,7 @@ public class OrbsOfLifeBranch extends AbstractUpgradeBranch<OrbsOfLife> {
                        """,
                 50000,
                 () -> {
-                    ability.getHealValues().getOrbHealing().value().addMultiplicativeModifierAdd("Orbs of Eruption", -.5f);
+                    ability.getHealValues().getOrbHealing().value().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Orbs of Eruption", -.5f);
                 }
         );
         masterUpgrade2 = new Upgrade(
@@ -44,7 +45,7 @@ public class OrbsOfLifeBranch extends AbstractUpgradeBranch<OrbsOfLife> {
                         """,
                 50000,
                 () -> {
-                    ability.getHealValues().getOrbHealing().value().addMultiplicativeModifierAdd("Orbs of Time", .3f);
+                    ability.getHealValues().getOrbHealing().value().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Orbs of Time", .3f);
                     ability.setOrbTickDuration(ability.getOrbTickDuration() * 2);
                     ability.setHealingIncrease(ability.getHealingIncrease() * 2);
                 }

--- a/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/revenant/RecklessChargeBranch.java
+++ b/src/main/java/com/ebicep/warlords/pve/upgrades/warrior/revenant/RecklessChargeBranch.java
@@ -3,6 +3,7 @@ package com.ebicep.warlords.pve.upgrades.warrior.revenant;
 import com.ebicep.warlords.abilities.RecklessCharge;
 import com.ebicep.warlords.abilities.internal.Value;
 import com.ebicep.warlords.pve.upgrades.*;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 
 public class RecklessChargeBranch extends AbstractUpgradeBranch<RecklessCharge> {
 
@@ -50,8 +51,8 @@ public class RecklessChargeBranch extends AbstractUpgradeBranch<RecklessCharge> 
                 50000,
                 () -> {
                     Value.RangedValueCritable damage = ability.getDamageValues().getChargeDamage();
-                    damage.min().addMultiplicativeModifierAdd("Master Upgrade Branch", 1.5f);
-                    damage.max().addMultiplicativeModifierAdd("Master Upgrade Branch", 1.5f);
+                    damage.min().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 1.5f);
+                    damage.max().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, "Master Upgrade Branch", 1.5f);
                     ability.setStunTimeInTicks(60);
                 }
         );

--- a/src/main/java/com/ebicep/warlords/pve/weapons/AbstractWeapon.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/AbstractWeapon.java
@@ -7,6 +7,7 @@ import com.ebicep.warlords.player.general.Weapons;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.util.bukkit.ItemBuilder;
 import com.ebicep.warlords.util.java.NumberFormat;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -79,7 +80,7 @@ public abstract class AbstractWeapon {
     }
 
     public void applyToWarlordsPlayer(WarlordsPlayer player, PveOption pveOption) {
-        player.getHealth().addAdditiveModifier("Weapon Health (Base)", getHealthBonus());
+        player.getHealth().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Weapon Health (Base)", getHealthBonus());
     }
 
     public abstract float getHealthBonus();

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/AbstractLegendaryWeapon.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/AbstractLegendaryWeapon.java
@@ -24,6 +24,7 @@ import com.ebicep.warlords.util.java.MathUtils;
 import com.ebicep.warlords.util.java.NumberFormat;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -276,15 +277,15 @@ public abstract class AbstractLegendaryWeapon extends AbstractWeapon implements 
         }
 
         AbstractPlayerClass playerClass = player.getSpec();
-        warlordsPlayer.getEnergyPerHit().addAdditiveModifier("Legendary Weapon", getEnergyPerHitBonus());
-        warlordsPlayer.getEnergyPerSec().addAdditiveModifier("Legendary Weapon", getEnergyPerSecondBonus());
+        warlordsPlayer.getEnergyPerHit().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Legendary Weapon", getEnergyPerHitBonus());
+        warlordsPlayer.getEnergyPerSec().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Legendary Weapon", getEnergyPerSecondBonus());
 
         for (AbstractAbility ability : playerClass.getAbilities()) {
             if (ability.getClass().equals(selectedSkillBoost.ability)) {
                 Value.applyDamageHealing(ability, value -> {
                             if (value instanceof Value.RangedValueCritable rangedValueCritable) {
-                                rangedValueCritable.critChance().addAdditiveModifier("Legendary Weapon", getSkillCritChanceBonus());
-                                rangedValueCritable.critMultiplier().addAdditiveModifier("Legendary Weapon", getSkillCritMultiplierBonus());
+                                rangedValueCritable.critChance().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Legendary Weapon", getSkillCritChanceBonus());
+                                rangedValueCritable.critMultiplier().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Legendary Weapon", getSkillCritMultiplierBonus());
                             }
                         }
                 );

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryAegis.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryAegis.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.PassiveCounter;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -132,7 +133,7 @@ public class LegendaryAegis extends AbstractLegendaryWeapon implements PassiveCo
                 }
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
             if (barrierActive()) {
-                currentDamageValue.addMultiplicativeModifierMult(getTitleName(), 1f + DMG_BONUS_WHILE_BARRIER_PERCENT / 100f);
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), 1f + DMG_BONUS_WHILE_BARRIER_PERCENT / 100f);
             }
                 }
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
@@ -145,7 +146,7 @@ public class LegendaryAegis extends AbstractLegendaryWeapon implements PassiveCo
                     if (barrierPool <= 0f) {
                         tryTriggerPulse(player);
                     }
-                    currentDamageValue.addAdditiveModifier(getTitleName(), -absorb);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.ADDITIVE, getTitleName(), -absorb);
                 }
         ));
         new GameRunnable(player.getGame()) {

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryAnchor.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryAnchor.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.PassiveCounter;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -103,7 +104,7 @@ public class LegendaryAnchor extends AbstractLegendaryWeapon implements PassiveC
                 false
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                     float dr = (stacks * getDrPerStack()) / 100f;
-                    currentDamageValue.addMultiplicativeModifierMult(getTitleName(), (1f - dr));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), (1f - dr));
                 }
         ));
 

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryArbalest.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryArbalest.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.pve.Currencies;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendaryWeapon;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -93,7 +94,7 @@ public class LegendaryArbalest extends AbstractLegendaryWeapon implements EventT
                 false
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (event.getWarlordsEntity().getCurrentHealth() < playerHPCheck) {
-                        currentDamageValue.addMultiplicativeModifierMult(getTitleName(), damageBoost);
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), damageBoost);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryBastion.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryBastion.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.GameRunnable;
 import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -197,7 +198,7 @@ public class LegendaryBastion extends AbstractLegendaryWeapon {
                     redirectUsedThisSecond += toRedirect;
                 }
             }
-            currentDamageValue.addMultiplicativeModifierMult(getTitleName(), 1f - dr);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), 1f - dr);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryBenevolent.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryBenevolent.java
@@ -6,6 +6,7 @@ import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendaryWeapon;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -62,7 +63,7 @@ public class LegendaryBenevolent extends AbstractLegendaryWeapon {
                 if (event.isHealingInstance() && event.getSource().equals(player)) {
                     float healingIncrease = 1 + (HEALING_INCREASE + HEALING_INCREASE_PER_UPGRADE * getTitleLevel()) / 100f;
                     event.applyToMinMax(floatModifiable ->
-                            floatModifiable.addMultiplicativeModifierMult(getTitleName(), healingIncrease)
+                            floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), healingIncrease)
                     );
                 }
             }

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryBrilliance.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryBrilliance.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.PassiveCounter;
 import com.ebicep.warlords.util.bukkit.ComponentBuilder;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -123,10 +124,10 @@ public class LegendaryBrilliance extends AbstractLegendaryWeapon implements Pass
                         },
                         200
                 ).addModifier(Modifier.MODIFY_INCOMING_HEALING, (event, currentHealValue) -> {
-                            currentHealValue.addMultiplicativeModifierMult(getTitleName(), 1.4f);
+                    currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), 1.4f);
                         }
                 ).addModifier(Modifier.MODIFY_OUTGOING_HEALING, (event, currentHealValue) -> {
-                            currentHealValue.addMultiplicativeModifierMult(getTitleName(), healBoost);
+                    currentHealValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), healBoost);
                         }
                 ));
                 player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1, 2);

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryChaotic.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryChaotic.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendary
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.util.bukkit.ComponentBuilder;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -178,14 +179,17 @@ public class LegendaryChaotic extends AbstractLegendaryWeapon implements Listene
                         if (!abilityNames.contains(e.getCause())) {
                             return;
                         }
-                        currentCritChance.addAdditiveModifier(getTitleName(), CRIT_CHANCE * stacks);
+                currentCritChance.addModifier(FloatModifiable.ModifierType.ADDITIVE, getTitleName(), CRIT_CHANCE * stacks);
                     }
             );
             cooldown.addModifier(Modifier.MODIFY_OUTGOING_CRIT_MULTIPLIER, (e, currentCritMultiplier) -> {
                         if (!abilityNames.contains(e.getCause())) {
                             return;
                         }
-                        currentCritMultiplier.addAdditiveModifier(getTitleName(), (CRIT_MULTIPLIER + CRIT_MULTIPLIER_PER_UPGRADE * getTitleLevel()) * stacks);
+                currentCritMultiplier.addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                        getTitleName(),
+                        (CRIT_MULTIPLIER + CRIT_MULTIPLIER_PER_UPGRADE * getTitleLevel()) * stacks
+                );
                     }
             );
             warlordsPlayer.getCooldownManager().addCooldown(cooldown);

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryDivine.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryDivine.java
@@ -148,7 +148,7 @@ public class LegendaryDivine extends AbstractLegendaryWeapon implements PassiveC
                                 DURATION * 20
                         );
                         regularCooldown.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (e, currentDamageValue) -> {
-                                    currentDamageValue.addMultiplicativeModifierMult(getTitleName(), 1 + damageBoost.get() * DAMAGE_BOOST / 100f);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), 1 + damageBoost.get() * DAMAGE_BOOST / 100f);
                                 }
                         );
                         cooldown.set(regularCooldown);
@@ -188,7 +188,9 @@ public class LegendaryDivine extends AbstractLegendaryWeapon implements PassiveC
                         List<FloatModifiable.FloatModifier> modifiers = new ArrayList<>();
                         for (AbstractAbility ability : player.getSpec().getAbilities()) {
                             if (ability.getEnergyCostValue() > 0) {
-                                modifiers.add(ability.getEnergyCost().addMultiplicativeModifierAdd("Divine", energyCostReduction));
+                                modifiers.add(ability.getEnergyCost().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                                        "Divine", energyCostReduction
+                                ));
                             }
                         }
                         RegularCooldown<LegendaryDivine> divineCooldown = new RegularCooldown<>(
@@ -207,10 +209,13 @@ public class LegendaryDivine extends AbstractLegendaryWeapon implements PassiveC
                                 10 * 20
                         );
                         divineCooldown.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                                    currentDamageValue.addMultiplicativeModifierMult(getTitleName(), 1 + ABILITY_DAMAGE_BOOST / 100f);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), 1 + ABILITY_DAMAGE_BOOST / 100f);
                                 }
                         );
-                        divineCooldown.addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier("Divine Ability", 2.5f));
+                        divineCooldown.addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                                        "Divine Ability", 2.5f
+                                )
+                        );
                         player.getCooldownManager().addCooldown(divineCooldown);
                         passiveCooldown = 40 * GameRunnable.SECOND;
                     }

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryEverlasting.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryEverlasting.java
@@ -14,6 +14,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendary
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.util.bukkit.ComponentBuilder;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -181,7 +182,7 @@ public class LegendaryEverlasting extends AbstractLegendaryWeapon implements Lis
                     (DURATION + DURATION_PER_UPGRADE * getTitleLevel()) * 20
             );
             cd.addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (e, currentDamageValue) -> {
-                        currentDamageValue.addMultiplicativeModifierMult(getTitleName(), (1 - stacks * reduction));
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), (1 - stacks * reduction));
                     }
             );
             warlordsPlayer.getCooldownManager().addCooldown(cooldown = cd);

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryFervent.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryFervent.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.PassiveCounter;
 import com.ebicep.warlords.util.java.NumberFormat;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import com.google.common.util.concurrent.AtomicDouble;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
@@ -139,7 +140,7 @@ public class LegendaryFervent extends AbstractLegendaryWeapon implements Passive
                                 DURATION * 20
                         );
                         regularCooldown.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (e, currentDamageValue) -> {
-                                    currentDamageValue.addMultiplicativeModifierMult(getTitleName(), 1 + damageBoost.get() * DAMAGE_BOOST / 100f);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), 1 + damageBoost.get() * DAMAGE_BOOST / 100f);
                                 }
                         );
                         cooldown.set(regularCooldown);
@@ -200,7 +201,7 @@ public class LegendaryFervent extends AbstractLegendaryWeapon implements Passive
                                     }
 
                                     float strikeDamageBoost = 1 + (ABILITY_STRIKE_DAMAGE_BOOST + ABILITY_STRIKE_DAMAGE_BOOST_PER_UPGRADE * getTitleLevel()) / 100f;
-                                    currentDamageValue.addMultiplicativeModifierMult(getTitleName(), strikeDamageBoost);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), strikeDamageBoost);
                                 }
                         ));
                         passiveCooldown = 40 * GameRunnable.SECOND;

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryFlux.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryFlux.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.PassiveCounter;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -170,7 +171,7 @@ public class LegendaryFlux extends AbstractLegendaryWeapon implements PassiveCou
                 }
         ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> {
                     if (hasFluxBuff(player)) {
-                        energyGainPerTick.addMultiplicativeModifierMult(getTitleName(), 1f + getRegenBonusPercent() / 100f);
+                        energyGainPerTick.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), 1f + getRegenBonusPercent() / 100f);
                     }
                 }
         ));
@@ -211,7 +212,7 @@ public class LegendaryFlux extends AbstractLegendaryWeapon implements PassiveCou
     private void startFluxBuff(WarlordsPlayer player) {
         float mult = 1f - (getCdrPercent() / 100f);
         player.getAbilities().forEach(ab ->
-                ab.getCooldown().addMultiplicativeModifierMult(CDR_MOD_KEY, mult)
+                ab.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, CDR_MOD_KEY, mult)
         );
 
         player.getCooldownManager().addCooldown(new RegularCooldown<>(
@@ -223,7 +224,7 @@ public class LegendaryFlux extends AbstractLegendaryWeapon implements PassiveCou
                 CooldownTypes.BUFF,
                 cm -> { // clean up cdr
                     player.getAbilities().forEach(ab ->
-                            ab.getCooldown().addMultiplicativeModifierMult(CDR_MOD_KEY, 1f)
+                            ab.getCooldown().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, CDR_MOD_KEY, 1f)
                     );
                 },
                 BUFF_DURATION_SECONDS * 20

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryFulcrum.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryFulcrum.java
@@ -13,6 +13,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.PassiveCounter;
 import com.ebicep.warlords.util.bukkit.ComponentBuilder;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -141,7 +142,10 @@ public class LegendaryFulcrum extends AbstractLegendaryWeapon implements GardenO
                         e.getWarlordsEntity().getCooldownManager().queueUpdatePlayerNames();
                     }
             );
-            fulcrumCooldown.addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier(getTitleName(), EPS_BOOST / 20f));
+            fulcrumCooldown.addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE,
+                            getTitleName(), EPS_BOOST / 20f
+                    )
+            );
                     player.getCooldownManager().addCooldown(fulcrumCooldown);
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryGale.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryGale.java
@@ -146,7 +146,7 @@ public class LegendaryGale extends AbstractLegendaryWeapon {
             List<FloatModifiable.FloatModifier> modifiers = wp
                     .getAbilities()
                     .stream()
-                    .map(a -> a.getEnergyCost().addAdditiveModifier("Gale", -abilityEnergyDecrease))
+                    .map(a -> a.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Gale", -abilityEnergyDecrease))
                     .toList();
             RegularCooldown<LegendaryGale> galeCooldown = new RegularCooldown<>(
                     name,

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryHuntsman.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryHuntsman.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendary
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.PassiveCounter;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -123,7 +124,7 @@ public class LegendaryHuntsman extends AbstractLegendaryWeapon implements Passiv
                 false
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     if (isTargetFar(player, event, RANGED_MIN_DISTANCE_BLOCKS)) {
-                        currentDamageValue.addMultiplicativeModifierMult(getTitleName(), (1f + getRangedBonusPercent() / 100f));
+                        currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), (1f + getRangedBonusPercent() / 100f));
                     }
 
                     if (isMeleeHit(event)) {
@@ -174,7 +175,7 @@ public class LegendaryHuntsman extends AbstractLegendaryWeapon implements Passiv
 
                     float dr = getMeleeGuardDrPercent() / 100f;
                     dr = Math.min(dr, 0.6f);
-                    currentDamageValue.addMultiplicativeModifierMult(getTitleName(), (1f - dr));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), (1f - dr));
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryInanition.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryInanition.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.pve.Currencies;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendaryWeapon;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -89,7 +90,7 @@ public class LegendaryInanition extends AbstractLegendaryWeapon implements Event
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     int debuffs = event.getWarlordsEntity().getCooldownManager().getDebuffCooldowns(true).size();
                     float damageBoost = 1 + Math.min(debuffs * debuffDamageBoost, maxDebuffDamageBoost);
-                    currentDamageValue.addMultiplicativeModifierMult(getTitleName(), damageBoost);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), damageBoost);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryIncendiary.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryIncendiary.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendary
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -83,7 +84,8 @@ public class LegendaryIncendiary extends AbstractLegendaryWeapon implements Even
 
         float critChanceBoost = CRIT_CHANCE_BOOST + CRIT_CHANCE_BOOST_INCREASE_PER_UPGRADE * getTitleLevel();
 
-        player.getEnergyPerHit().addMultiplicativeModifierAdd(getTitleName(), (EPH_PERCENT_INCREASE + EPH_PERCENT_INCREASE_PER_UPGRADE * getTitleLevel()) / 100);
+        player.getEnergyPerHit()
+              .addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE, getTitleName(), (EPH_PERCENT_INCREASE + EPH_PERCENT_INCREASE_PER_UPGRADE * getTitleLevel()) / 100);
         player.getCooldownManager().addCooldown(new PermanentCooldown<>(
                 getTitleName(),
                 null,
@@ -97,7 +99,7 @@ public class LegendaryIncendiary extends AbstractLegendaryWeapon implements Even
         ).addModifier(Modifier.MODIFY_OUTGOING_CRIT_CHANCE, (event, currentCritChance) -> {
                     String ability = event.getCause();
                     if (Utils.isProjectile(ability) || ability.equals("Boulder")) {
-                        currentCritChance.addAdditiveModifier(getTitleName(), critChanceBoost);
+                        currentCritChance.addModifier(FloatModifiable.ModifierType.ADDITIVE, getTitleName(), critChanceBoost);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryJuggernaut.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryJuggernaut.java
@@ -86,7 +86,9 @@ public class LegendaryJuggernaut extends AbstractLegendaryWeapon implements Even
         super.applyToWarlordsPlayer(player, pveOption);
 
         player.getGame().registerEvents(new Listener() {
-            final FloatModifiable.FloatModifier modifier = player.getHealth().addMultiplicativeModifierAdd(getTitleName() + " (Base)", 0);
+            final FloatModifiable.FloatModifier modifier = player.getHealth().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                    getTitleName() + " (Base)", 0
+            );
 
             @EventHandler(ignoreCancelled = true)
             public void onDeath(WarlordsDeathEvent event) {
@@ -114,7 +116,7 @@ public class LegendaryJuggernaut extends AbstractLegendaryWeapon implements Even
                     for (int i = KILL_MILESTONES.size() - 1; i >= 0; i--) {
                         int killMilestone = KILL_MILESTONES.get(i);
                         if (playerKills >= killMilestone) {
-                            currentDamageValue.addMultiplicativeModifierMult(getTitleName(), 1 + (getDamageBoost() * (i + 1)) / 100f);
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), 1 + (getDamageBoost() * (i + 1)) / 100f);
                             return;
                         }
                     }

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryMomentum.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryMomentum.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.PassiveCounter;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.GameRunnable;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -118,12 +119,12 @@ public class LegendaryMomentum extends AbstractLegendaryWeapon implements Passiv
                 false
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
                     float mul = 1f + (stacks * DMG_PER_STACK_PERCENT) / 100f;
-                    currentDamageValue.addMultiplicativeModifierMult(getTitleName(), mul);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), mul);
                 }
         ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
             float dr = (stacks * DR_PER_STACK_PERCENT) / 100f;
             dr = Math.min(dr, 0.6f);
-            currentDamageValue.addMultiplicativeModifierMult(getTitleName(), (1f - dr));
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), (1f - dr));
                 }
         ));
 

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryParadox.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryParadox.java
@@ -19,6 +19,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendary
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.PassiveCounter;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -207,7 +208,7 @@ public class LegendaryParadox extends AbstractLegendaryWeapon implements GardenO
                     }
                 })
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(getTitleName(), damageBoost);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), damageBoost);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryReliquary.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryReliquary.java
@@ -9,6 +9,7 @@ import com.ebicep.warlords.pve.Currencies;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendaryWeapon;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -97,10 +98,10 @@ public class LegendaryReliquary extends AbstractLegendaryWeapon implements Event
                 },
                 false
         ).addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(getTitleName(), outgoingDamageIncrease);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), outgoingDamageIncrease);
                 }
         ).addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-            currentDamageValue.addMultiplicativeModifierMult(getTitleName(), incomingDamageIncrease);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), incomingDamageIncrease);
                 }
         ));
     }

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryRevered.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryRevered.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.pve.Currencies;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendaryWeapon;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -170,7 +171,10 @@ public class LegendaryRevered extends AbstractLegendaryWeapon implements EventTi
                 (int) ((DURATION + DURATION_INCREASE_PER_UPGRADE * getTitleLevel()) * 20)
         );
         cooldown.addModifier(Modifier.OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
-                    currentDamageValue.addMultiplicativeModifierMult(getTitleName(), 1 + (DAMAGE_INCREASE + DAMAGE_INCREASE_PER_UPGRADE * getTitleLevel()) / 100f);
+            currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                    getTitleName(),
+                    1 + (DAMAGE_INCREASE + DAMAGE_INCREASE_PER_UPGRADE * getTitleLevel()) / 100f
+            );
                 }
         );
         return cooldown;

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryStalwart.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryStalwart.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendary
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.PassiveCounter;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -124,12 +125,12 @@ public class LegendaryStalwart extends AbstractLegendaryWeapon implements Passiv
                                     },
                                     REDUCTION_DURATION * 20
                             ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (e, currentDamageValue2) -> {
-                                        currentDamageValue2.addMultiplicativeModifierMult("Stalwart", .01f);
+                                currentDamageValue2.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, "Stalwart", .01f);
                                     }
                             ));
                             player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1, 2);
                             player.sendMessage(Component.text("Triggered Stalwart! +99% damage reduction for 5s.", NamedTextColor.GREEN));
-                            currentDamageValue.addOverridingModifier("Stalwart", 0);
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.OVERRIDING, "Stalwart", 0);
                         }
                 ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (event, currentDamageValue) -> {
                             if (player.getCurrentHealth() >= player.getMaxHealth() * upperBoundHP) {
@@ -138,7 +139,7 @@ public class LegendaryStalwart extends AbstractLegendaryWeapon implements Passiv
                             float currentHpPercent = player.getCurrentHealth() / player.getMaxHealth();
                             int timesToReduce = (int) ((getUnderHpCheck() - currentHpPercent) / getEveryHpPercent());
                             float reduction = Math.min(timesToReduce * .075f, .8f);
-                            currentDamageValue.addMultiplicativeModifierMult(getTitleName(), (1 - reduction));
+                    currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), (1 - reduction));
                         }
                 )
         );

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendarySuspicious.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendarySuspicious.java
@@ -11,6 +11,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendary
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.util.java.Pair;
 import com.ebicep.warlords.util.warlords.Utils;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -115,7 +116,7 @@ public class LegendarySuspicious extends AbstractLegendaryWeapon {
                 false
         ).addModifier(Modifier.MODIFY_OUTGOING_CRIT_CHANCE, (event, currentCritChance) -> {
                     if (event.getCause().isEmpty()) {
-                        currentCritChance.addOverridingModifier("Suspicious Weapon", 50);
+                        currentCritChance.addModifier(FloatModifiable.ModifierType.OVERRIDING, "Suspicious Weapon", 50);
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryTitanic.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryTitanic.java
@@ -58,7 +58,9 @@ public class LegendaryTitanic extends AbstractLegendaryWeapon {
         super.applyToWarlordsPlayer(player, pveOption);
 
         player.getGame().registerEvents(new Listener() {
-            final FloatModifiable.FloatModifier modifier = player.getHealth().addMultiplicativeModifierAdd(getTitleName() + " (Base)", 0);
+            final FloatModifiable.FloatModifier modifier = player.getHealth().addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_ADDITIVE,
+                    getTitleName() + " (Base)", 0
+            );
             @EventHandler
             public void onEvent(WarlordsUpgradeUnlockEvent event) {
                 if (event.getWarlordsEntity() == player) {

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryValiant.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryValiant.java
@@ -1,7 +1,6 @@
 package com.ebicep.warlords.pve.weapons.weapontypes.legendaries.titles;
 
 import com.ebicep.warlords.game.option.pve.PveOption;
-import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
@@ -10,6 +9,7 @@ import com.ebicep.warlords.pve.Currencies;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendaryWeapon;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -92,12 +92,18 @@ public class LegendaryValiant extends AbstractLegendaryWeapon implements EventTi
                 false
         ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> {
                     if (player.getCurrentHealth() == player.getMaxHealth()) {
-                        energyGainPerTick.addMultiplicativeModifierMult(getTitleName(), (1 + (EPS_INCREASE + EPS_INCREASE_PER_UPGRADE * getTitleLevel()) / 100f));
+                        energyGainPerTick.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                getTitleName(),
+                                (1 + (EPS_INCREASE + EPS_INCREASE_PER_UPGRADE * getTitleLevel()) / 100f)
+                        );
                     }
                 }
         ).addModifier(Modifier.ENERGY_GAIN_PER_HIT, energyGainPerHit -> {
                     if (player.getCurrentHealth() == player.getMaxHealth()) {
-                        energyGainPerHit.addMultiplicativeModifierMult(getTitleName(), (1 + (EPS_INCREASE + EPS_INCREASE_PER_UPGRADE * getTitleLevel()) / 100f));
+                        energyGainPerHit.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE,
+                                getTitleName(),
+                                (1 + (EPS_INCREASE + EPS_INCREASE_PER_UPGRADE * getTitleLevel()) / 100f)
+                        );
                     }
                 }
         ));

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryVigorous.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryVigorous.java
@@ -10,6 +10,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendary
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.util.bukkit.ComponentBuilder;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -145,7 +146,7 @@ public class LegendaryVigorous extends AbstractLegendaryWeapon {
                     cooldownManager -> {
                     },
                     duration * 20
-            ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addAdditiveModifier(name, energyPerSecond / 20f)));
+            ).addModifier(Modifier.ENERGY_GAIN_PER_TICK, energyGainPerTick -> energyGainPerTick.addModifier(FloatModifiable.ModifierType.ADDITIVE, name, energyPerSecond / 20f)));
             return true;
         }
 

--- a/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryVorpal.java
+++ b/src/main/java/com/ebicep/warlords/pve/weapons/weapontypes/legendaries/titles/LegendaryVorpal.java
@@ -12,6 +12,7 @@ import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.AbstractLegendary
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.LegendaryTitles;
 import com.ebicep.warlords.pve.weapons.weapontypes.legendaries.PassiveCounter;
 import com.ebicep.warlords.util.java.Pair;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -122,7 +123,7 @@ public class LegendaryVorpal extends AbstractLegendaryWeapon implements PassiveC
                                 cooldownManager.hasCooldownFromName("Earthliving Weapon") && ability.equals("Earthliving Weapon")
                 ) {
                     event.applyToMinMax(floatModifiable ->
-                            floatModifiable.addMultiplicativeModifierMult(getTitleName(), meleeDamageBoost)
+                            floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), meleeDamageBoost)
                     );
                     return;
                 }
@@ -136,13 +137,13 @@ public class LegendaryVorpal extends AbstractLegendaryWeapon implements PassiveC
                         cooldownManager.hasCooldownFromName("Soulbinding Weapon")
                 ) {
                     event.applyToMinMax(floatModifiable ->
-                            floatModifiable.addMultiplicativeModifierMult(getTitleName(), meleeDamageBoost)
+                            floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), meleeDamageBoost)
                     );
                 }
                 if (meleeCounter % 4 == 0) {
                     player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1, 2);
                     event.applyToMinMax(floatModifiable ->
-                            floatModifiable.addMultiplicativeModifierMult(getTitleName(), 7)
+                            floatModifiable.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, getTitleName(), 7)
                     );
                     event.getFlags().add(InstanceFlags.TRUE_DAMAGE);
                 }

--- a/src/main/java/com/ebicep/warlords/util/warlords/modifiablevalues/FloatModifiable.java
+++ b/src/main/java/com/ebicep/warlords/util/warlords/modifiablevalues/FloatModifiable.java
@@ -9,7 +9,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import java.util.*;
 import java.util.function.Consumer;
 
-public class FloatModifiable {
+public class FloatModifiable implements Modifiable {
 
     private final List<FloatModifier> overridingModifiers = new ArrayList<>(); // these modifiers override the current value
     private final List<FloatModifier> additiveModifiers = new ArrayList<>();
@@ -26,18 +26,6 @@ public class FloatModifiable {
         this.filters.put("Base", new BaseFilter());
         this.marginalContributions.put("Base", new HashMap<>(4));
         refresh();
-    }
-
-    public void refresh() {
-        if (!overridingModifiers.isEmpty()) {
-            processOverridingModifiers();
-        } else {
-            processNormalModifiers();
-        }
-        // Call global refresh listeners AFTER processing
-        if (!onRefresh.isEmpty()) {
-            onRefresh.values().forEach(Runnable::run);
-        }
     }
 
     private void processOverridingModifiers() {
@@ -238,15 +226,63 @@ public class FloatModifiable {
         refresh();
     }
 
-    public FloatModifier addAdditiveModifier(String log, float additiveModifier) {
-        return addAdditiveModifier(log, additiveModifier, -1, null);
+    public void addFilter(FloatModifiableFilter floatModifiableFilter) {
+        filters.put(floatModifiableFilter.getName(), floatModifiableFilter);
+        refresh();
     }
 
-    public FloatModifier addAdditiveModifier(String log, float additiveModifier, int ticksLeft, Consumer<Float> callback) {
-        FloatModifier modifier = new FloatModifier(log, additiveModifier, ticksLeft, callback);
-        callOnAddModifier(ModifierType.ADDITIVE, modifier);
-        addModifier(this.additiveModifiers, modifier);
-        return modifier;
+    public Map<String, Float> getMarginalContributions(String filterName) {
+        return marginalContributions.getOrDefault(filterName, Collections.emptyMap());
+    }
+
+    public void callContributionCallbacks(Map<String, Float> contributions) {
+        if (contributions == null) {
+            return;
+        }
+        callContributionCallback(contributions, overridingModifiers);
+        callContributionCallback(contributions, additiveModifiers);
+        callContributionCallback(contributions, multiplicativeModifiersAdditive);
+        callContributionCallback(contributions, multiplicativeModifiersMultiplicative);
+    }
+
+    public List<Component> getDebugInfo() {
+        return getDebugInfo(null);
+    }
+
+    public List<Component> getDebugInfo(Map<String, Float> globalContributions) {
+        List<Component> components = new ArrayList<>();
+        FloatModifiableFilter base = filters.get("Base");
+        if (getCalculatedValue() != baseValue) {
+            components.add(Component.textOfChildren(
+                    getDebugInfo("Base", baseValue),
+                    Component.text(" -> ", NamedTextColor.GRAY),
+                    getDebugInfo("Calculated", getCalculatedValue())
+            ));
+        } else {
+            components.add(getDebugInfo("Calculated", getCalculatedValue()));
+        }
+        if (!overridingModifiers.isEmpty()) {
+            components.add(getDebugInfo("Overriding", overridingModifiers.get(0).getModifier()));
+            components.addAll(getDebugInfo(overridingModifiers, globalContributions));
+        }
+        if (!additiveModifiers.isEmpty()) {
+            components.add(getDebugInfo("Additive", base.getCachedAdditiveModifier()));
+            components.addAll(getDebugInfo(additiveModifiers, globalContributions));
+        }
+        if (!multiplicativeModifiersAdditive.isEmpty()) {
+            components.add(getDebugInfo("Additive Multiplier", base.getCachedMultiplicativeModifierAdditive(), "x"));
+            components.addAll(getDebugInfo(multiplicativeModifiersAdditive, globalContributions));
+        }
+        if (!multiplicativeModifiersMultiplicative.isEmpty()) {
+            components.add(getDebugInfo("Multiplicative Multiplier", base.getCachedMultiplicativeModifierMultiplicative(), "x"));
+            components.addAll(getDebugInfo(multiplicativeModifiersMultiplicative, globalContributions));
+        }
+        return components;
+    }
+
+    @Override
+    public float getCalculatedValue() {
+        return filters.get("Base").getCachedValue();
     }
 
     private void callOnAddModifier(ModifierType type, FloatModifier modifier) {
@@ -262,140 +298,134 @@ public class FloatModifiable {
         refresh();
     }
 
-    public FloatModifier addOverridingModifier(String log, float overridingModifier) {
-        return addOverridingModifier(log, overridingModifier, -1, null);
+    @Override
+    public void refresh() {
+        if (!overridingModifiers.isEmpty()) {
+            processOverridingModifiers();
+        } else {
+            processNormalModifiers();
+        }
+        // Call global refresh listeners AFTER processing
+        if (!onRefresh.isEmpty()) {
+            onRefresh.values().forEach(Runnable::run);
+        }
     }
 
-    public FloatModifier addOverridingModifier(String log, float overridingModifier, int ticksLeft, Consumer<Float> callback) {
-        FloatModifier modifier = new FloatModifier(log, overridingModifier, ticksLeft, callback);
-        callOnAddModifier(ModifierType.OVERRIDING, modifier);
-        addModifier(this.overridingModifiers, modifier);
-        return modifier;
-    }
-
-    public FloatModifier addOverridingModifier(String log, float overridingModifier, int ticksLeft) {
-        return addOverridingModifier(log, overridingModifier, ticksLeft, null);
-    }
-
-    public FloatModifier addOverridingModifier(String log, float overridingModifier, Consumer<Float> callback) {
-        return addOverridingModifier(log, overridingModifier, -1, callback);
-    }
-
-    public FloatModifier addAdditiveModifier(String log, float additiveModifier, int ticksLeft) {
-        return addAdditiveModifier(log, additiveModifier, ticksLeft, null);
-    }
-
-    public FloatModifier addAdditiveModifier(String log, float additiveModifier, Consumer<Float> callback) {
-        return addAdditiveModifier(log, additiveModifier, -1, callback);
-    }
-
-    public FloatModifier addMultiplicativeModifierAdd(String log, float multiplicativeModifier) {
-        return addMultiplicativeModifierAdd(log, multiplicativeModifier, true);
-    }
-
-    public FloatModifier addMultiplicativeModifierAdd(String log, float multiplicativeModifier, boolean override) {
+    @Override
+    public FloatModifiable.FloatModifier addModifier(
+            FloatModifiable.ModifierType type,
+            String log,
+            float value,
+            int ticksLeft,
+            Consumer<Float> callback,
+            boolean override
+    ) {
+        List<FloatModifiable.FloatModifier> list = switch (type) {
+            case OVERRIDING -> this.overridingModifiers;
+            case ADDITIVE -> this.additiveModifiers;
+            case MULTIPLICATIVE_ADDITIVE -> this.multiplicativeModifiersAdditive;
+            case MULTIPLICATIVE_MULTIPLICATIVE -> this.multiplicativeModifiersMultiplicative;
+        };
         if (!override) {
-            for (FloatModifier modifier : multiplicativeModifiersAdditive) {
+            for (FloatModifier modifier : list) {
                 if (modifier.getLog().equals(log)) {
                     return modifier;
                 }
             }
         }
-        return addMultiplicativeModifierAdd(log, multiplicativeModifier, -1, null);
-    }
-
-    public FloatModifier addMultiplicativeModifierAdd(String log, float multiplicativeModifier, int ticksLeft, Consumer<Float> callback) {
-        FloatModifier modifier = new FloatModifier(log, multiplicativeModifier, ticksLeft, callback);
-        callOnAddModifier(ModifierType.MULTIPLICATIVE_ADDITIVE, modifier);
-        addModifier(this.multiplicativeModifiersAdditive, modifier);
+        FloatModifiable.FloatModifier modifier = new FloatModifiable.FloatModifier(log, value, ticksLeft, callback);
+        callOnAddModifier(type, modifier);
+        addModifier(list, modifier);
         return modifier;
     }
 
-    public FloatModifier addMultiplicativeModifierAdd(String log, float multiplicativeModifier, Consumer<Float> callback) {
-        return addMultiplicativeModifierAdd(log, multiplicativeModifier, -1, callback);
+    @Override
+    public FloatModifier addModifier(ModifierType type, String log, float value, boolean override) {
+        return addModifier(type, log, value, -1, null, override);
     }
 
-    public FloatModifier addMultiplicativeModifierAdd(String log, float multiplicativeModifier, int ticksLeft) {
-        return addMultiplicativeModifierAdd(log, multiplicativeModifier, ticksLeft, null);
+    @Override
+    public FloatModifier addModifier(ModifierType type, String log, float value) {
+        return addModifier(type, log, value, -1, null, true);
     }
 
-    public FloatModifier addMultiplicativeModifierMult(String log, float multiplicativeModifier) {
-        return addMultiplicativeModifierMult(log, multiplicativeModifier, -1, null);
+    @Override
+    public FloatModifier addModifier(ModifierType type, String log, float value, int ticksLeft) {
+        return addModifier(type, log, value, ticksLeft, null, true);
     }
 
-    public FloatModifier addMultiplicativeModifierMult(String log, float multiplicativeModifier, int ticksLeft, Consumer<Float> callback) {
-        FloatModifier modifier = new FloatModifier(log, multiplicativeModifier, ticksLeft, callback);
-        callOnAddModifier(ModifierType.MULTIPLICATIVE_MULTIPLICATIVE, modifier);
-        addModifier(this.multiplicativeModifiersMultiplicative, modifier);
-        return modifier;
+    @Override
+    public FloatModifier addModifier(ModifierType type, String log, float value, Consumer<Float> callback) {
+        return addModifier(type, log, value, -1, callback, true);
     }
 
-    public FloatModifier addMultiplicativeModifierMult(String log, float multiplicativeModifier, Consumer<Float> callback) {
-        return addMultiplicativeModifierMult(log, multiplicativeModifier, -1, callback);
-    }
-
-    public FloatModifier addMultiplicativeModifierMult(String log, float multiplicativeModifier, int ticksLeft) {
-        return addMultiplicativeModifierMult(log, multiplicativeModifier, ticksLeft, null);
-    }
-
-    public void addFilter(FloatModifiableFilter floatModifiableFilter) {
-        filters.put(floatModifiableFilter.getName(), floatModifiableFilter);
-        refresh();
-    }
-
-    public List<Component> getDebugInfo() {
-        List<Component> components = new ArrayList<>();
-        FloatModifiableFilter base = filters.get("Base");
-        if (getCalculatedValue() != baseValue) {
-            components.add(Component.textOfChildren(
-                    getDebugInfo("Base", baseValue),
-                    Component.text(" -> ", NamedTextColor.GRAY),
-                    getDebugInfo("Calculated", getCalculatedValue())
-            ));
-        } else {
-            components.add(getDebugInfo("Calculated", getCalculatedValue()));
+    @Override
+    public void addModifierListener(Consumer<FloatModifier> consumer, ModifierType... modifierTypes) {
+        for (ModifierType modifierType : modifierTypes) {
+            onAddModifier.computeIfAbsent(modifierType, k -> new HashSet<>(2)).add(consumer);
         }
-        if (!overridingModifiers.isEmpty()) {
-            components.add(getDebugInfo("Overriding", overridingModifiers.get(0).getModifier()));
-            components.addAll(getDebugInfo(overridingModifiers));
-        }
-        if (!additiveModifiers.isEmpty()) {
-            components.add(getDebugInfo("Additive", base.getCachedAdditiveModifier()));
-            components.addAll(getDebugInfo(additiveModifiers));
-        }
-        if (!multiplicativeModifiersAdditive.isEmpty()) {
-            components.add(getDebugInfo("Additive Multiplier", base.getCachedMultiplicativeModifierAdditive(), "x"));
-            components.addAll(getDebugInfo(multiplicativeModifiersAdditive));
-        }
-        if (!multiplicativeModifiersMultiplicative.isEmpty()) {
-            components.add(getDebugInfo("Multiplicative Multiplier", base.getCachedMultiplicativeModifierMultiplicative(), "x"));
-            components.addAll(getDebugInfo(multiplicativeModifiersMultiplicative));
-        }
-        return components;
     }
 
-    public float getCalculatedValue() {
-        return filters.get("Base").getCachedValue();
+    @Override
+    public void removeModifierListener(Consumer<FloatModifier> consumer, ModifierType... modifierTypes) {
+        for (ModifierType modifierType : modifierTypes) {
+            Set<Consumer<FloatModifier>> consumers = onAddModifier.get(modifierType);
+            if (consumers != null) {
+                consumers.remove(consumer);
+            }
+        }
+    }
+
+    @Override
+    public void callContributionCallbacks() {
+        callContributionCallbacks("Base");
+    }
+
+    public void callContributionCallbacks(String filterName) {
+        Map<String, Float> contributions = marginalContributions.get(filterName);
+        if (contributions == null) {
+            return;
+        }
+        callContributionCallback(contributions, overridingModifiers);
+        callContributionCallback(contributions, additiveModifiers);
+        callContributionCallback(contributions, multiplicativeModifiersAdditive);
+        callContributionCallback(contributions, multiplicativeModifiersMultiplicative);
+    }
+
+    private void callContributionCallback(Map<String, Float> contributions, List<FloatModifier> modifiers) {
+        for (FloatModifier modifier : modifiers) {
+            Consumer<Float> callback = modifier.callback;
+            if (callback != null) {
+                callback.accept(contributions.getOrDefault(modifier.log, 0f));
+            }
+        }
     }
 
     private Component getDebugInfo(String name, float value) {
         return getDebugInfo(name, value, "");
     }
 
-    private List<Component> getDebugInfo(List<FloatModifier> modifiers) {
+    private List<Component> getDebugInfo(List<FloatModifier> modifiers, Map<String, Float> globalContributions) {
         Map<String, Float> contributions = marginalContributions.getOrDefault("Base", Collections.emptyMap());
         List<Component> result = new ArrayList<>(modifiers.size());
         for (FloatModifier floatModifier : modifiers) {
             String value = NumberFormat.formatOptionalHundredths(contributions.getOrDefault(floatModifier.getLog(), 0f));
-            result.add(ComponentBuilder
+            ComponentBuilder builder = ComponentBuilder
                     .create()
                     .text(" - ", NamedTextColor.WHITE)
                     .append(floatModifier.getDebugInfo())
                     .text(" (", NamedTextColor.GRAY)
                     .text(value, NamedTextColor.GOLD)
-                    .text(")", NamedTextColor.GRAY)
-                    .build()
-            );
+                    .text(")", NamedTextColor.GRAY);
+
+            if (globalContributions != null) {
+                String globalValue = NumberFormat.formatOptionalHundredths(globalContributions.getOrDefault(floatModifier.getLog(), 0f));
+                builder.text(" (", NamedTextColor.GRAY)
+                       .text(globalValue, NamedTextColor.GOLD)
+                       .text(")", NamedTextColor.GRAY);
+            }
+
+            result.add(builder.build());
         }
         return result;
     }
@@ -419,45 +449,6 @@ public class FloatModifiable {
 
     public void addRefreshListener(String source, Runnable runnable) {
         onRefresh.put(source, runnable);
-    }
-
-    public void addModifierListener(Consumer<FloatModifier> consumer, ModifierType... modifierTypes) {
-        for (ModifierType modifierType : modifierTypes) {
-            onAddModifier.computeIfAbsent(modifierType, k -> new HashSet<>(2)).add(consumer);
-        }
-    }
-
-    public void removeModifierListener(Consumer<FloatModifier> consumer, ModifierType... modifierTypes) {
-        for (ModifierType modifierType : modifierTypes) {
-            Set<Consumer<FloatModifier>> consumers = onAddModifier.get(modifierType);
-            if (consumers != null) {
-                consumers.remove(consumer);
-            }
-        }
-    }
-
-    public void callContributionCallbacks() {
-        callContributionCallbacks("Base");
-    }
-
-    public void callContributionCallbacks(String filterName) {
-        Map<String, Float> contributions = marginalContributions.get(filterName);
-        if (contributions == null) {
-            return;
-        }
-        callContributionCallback(contributions, overridingModifiers);
-        callContributionCallback(contributions, additiveModifiers);
-        callContributionCallback(contributions, multiplicativeModifiersAdditive);
-        callContributionCallback(contributions, multiplicativeModifiersMultiplicative);
-    }
-
-    private void callContributionCallback(Map<String, Float> contributions, List<FloatModifier> modifiers) {
-        for (FloatModifier modifier : modifiers) {
-            Consumer<Float> callback = modifier.callback;
-            if (callback != null) {
-                callback.accept(contributions.getOrDefault(modifier.log, 0f));
-            }
-        }
     }
 
     public enum ModifierType {
@@ -503,7 +494,7 @@ public class FloatModifiable {
                 builder.append(debugPrefix.build());
             }
             builder.text(log, isDisabled() ? NamedTextColor.RED : NamedTextColor.GREEN)
-                    .text(": ", NamedTextColor.GRAY)
+                   .text(": ", NamedTextColor.GRAY)
                    .text(NumberFormat.formatOptionalHundredths(modifier), NamedTextColor.YELLOW);
             if (ticksLeft != -1) {
                 builder.text(" (" + ticksLeft + ")", NamedTextColor.DARK_GRAY);

--- a/src/main/java/com/ebicep/warlords/util/warlords/modifiablevalues/Modifiable.java
+++ b/src/main/java/com/ebicep/warlords/util/warlords/modifiablevalues/Modifiable.java
@@ -1,0 +1,27 @@
+package com.ebicep.warlords.util.warlords.modifiablevalues;
+
+import java.util.function.Consumer;
+
+public interface Modifiable {
+
+    float getCalculatedValue();
+
+    void refresh();
+
+    FloatModifiable.FloatModifier addModifier(FloatModifiable.ModifierType type, String log, float value, int ticksLeft, Consumer<Float> callback, boolean override);
+
+    FloatModifiable.FloatModifier addModifier(FloatModifiable.ModifierType type, String log, float value, boolean override);
+
+    FloatModifiable.FloatModifier addModifier(FloatModifiable.ModifierType type, String log, float value);
+
+    FloatModifiable.FloatModifier addModifier(FloatModifiable.ModifierType type, String log, float value, int ticksLeft);
+
+    FloatModifiable.FloatModifier addModifier(FloatModifiable.ModifierType type, String log, float value, Consumer<Float> callback);
+
+    void addModifierListener(Consumer<FloatModifiable.FloatModifier> consumer, FloatModifiable.ModifierType... modifierTypes);
+
+    void removeModifierListener(Consumer<FloatModifiable.FloatModifier> consumer, FloatModifiable.ModifierType... modifierTypes);
+
+    void callContributionCallbacks();
+
+}

--- a/src/main/java/com/ebicep/warlords/util/warlords/modifiablevalues/MultiFloatModifiable.java
+++ b/src/main/java/com/ebicep/warlords/util/warlords/modifiablevalues/MultiFloatModifiable.java
@@ -1,0 +1,218 @@
+package com.ebicep.warlords.util.warlords.modifiablevalues;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+public class MultiFloatModifiable implements Modifiable {
+
+    private final Map<ApplyFloatModifiable, FloatModifiable> modifiables = new TreeMap<>(Comparator
+            .comparingInt(ApplyFloatModifiable::priority) // highest priority first
+            .reversed()
+            .thenComparing(ApplyFloatModifiable::applyType) // enum natural order (ordinal)
+    );
+    private final FloatModifiable baseModifiable;
+    private final Map<ApplyFloatModifiable, Map<String, Float>> globalMarginalContributions = new HashMap<>();
+
+    public MultiFloatModifiable(FloatModifiable baseModifiable) {
+        this.baseModifiable = baseModifiable;
+        this.modifiables.put(new ApplyFloatModifiable(100, ApplyFloatModifiableType.ADDITIVE), baseModifiable);
+    }
+
+    @Override
+    public float getCalculatedValue() {
+        float value = 0;
+        for (Map.Entry<ApplyFloatModifiable, FloatModifiable> entry : modifiables.entrySet()) {
+            ApplyFloatModifiable applyFloatModifiable = entry.getKey();
+            FloatModifiable floatModifiable = entry.getValue();
+            if (applyFloatModifiable.applyType() == ApplyFloatModifiableType.ADDITIVE) {
+                value += floatModifiable.getCalculatedValue();
+            } else if (applyFloatModifiable.applyType() == ApplyFloatModifiableType.MULTIPLICATIVE) {
+                value *= floatModifiable.getCalculatedValue();
+            }
+        }
+        return value;
+    }
+
+    @Override
+    public void refresh() {
+        for (FloatModifiable value : modifiables.values()) {
+            value.refresh();
+        }
+        calculateGlobalContributions();
+    }
+
+    @Override
+    public FloatModifiable.FloatModifier addModifier(FloatModifiable.ModifierType type, String log, float value, int ticksLeft, Consumer<Float> callback, boolean override) {
+        return baseModifiable.addModifier(type, log, value, ticksLeft, callback, override);
+    }
+
+    @Override
+    public FloatModifiable.FloatModifier addModifier(FloatModifiable.ModifierType type, String log, float value, boolean override) {
+        return null;
+    }
+
+    @Override
+    public FloatModifiable.FloatModifier addModifier(FloatModifiable.ModifierType type, String log, float value) {
+        return baseModifiable.addModifier(type, log, value);
+    }
+
+    @Override
+    public FloatModifiable.FloatModifier addModifier(FloatModifiable.ModifierType type, String log, float value, int ticksLeft) {
+        return baseModifiable.addModifier(type, log, value, ticksLeft);
+    }
+
+    @Override
+    public FloatModifiable.FloatModifier addModifier(FloatModifiable.ModifierType type, String log, float value, Consumer<Float> callback) {
+        return baseModifiable.addModifier(type, log, value, callback);
+    }
+
+    @Override
+    public void addModifierListener(Consumer<FloatModifiable.FloatModifier> consumer, FloatModifiable.ModifierType... modifierTypes) {
+        for (FloatModifiable value : modifiables.values()) {
+            value.addModifierListener(consumer, modifierTypes);
+        }
+    }
+
+    @Override
+    public void removeModifierListener(Consumer<FloatModifiable.FloatModifier> consumer, FloatModifiable.ModifierType... modifierTypes) {
+        for (FloatModifiable value : modifiables.values()) {
+            value.removeModifierListener(consumer, modifierTypes);
+        }
+    }
+
+    @Override
+    public void callContributionCallbacks() {
+        for (FloatModifiable value : modifiables.values()) {
+            value.callContributionCallbacks();
+        }
+    }
+
+    /**
+     * Use Chain Rule + Total Derivative to calculate global contributions
+     */
+    private void calculateGlobalContributions() {
+        globalMarginalContributions.values().forEach(Map::clear);
+
+        List<Map.Entry<ApplyFloatModifiable, FloatModifiable>> entries = new ArrayList<>(modifiables.entrySet());
+        int size = entries.size();
+
+        // pre-calculate future multipliers
+        float[] futureMultipliers = new float[size];
+        float currentFutureMult = 1.0f;
+
+        for (int i = size - 1; i >= 0; i--) {
+            futureMultipliers[i] = currentFutureMult;
+            Map.Entry<ApplyFloatModifiable, FloatModifiable> entry = entries.get(i);
+            if (entry.getKey().applyType() == ApplyFloatModifiableType.MULTIPLICATIVE) {
+                currentFutureMult *= entry.getValue().getCalculatedValue();
+            }
+        }
+
+        // calculate Global Contributions per layer
+        float currentAccumulator = 0f;
+
+        for (int i = 0; i < size; i++) {
+            Map.Entry<ApplyFloatModifiable, FloatModifiable> entry = entries.get(i);
+            ApplyFloatModifiable key = entry.getKey();
+            FloatModifiable fm = entry.getValue();
+
+            float localValue = fm.getCalculatedValue();
+            float scaleForEntry;
+
+            if (key.applyType() == ApplyFloatModifiableType.ADDITIVE) {
+                scaleForEntry = futureMultipliers[i];
+                currentAccumulator += localValue;
+            } else {
+                scaleForEntry = currentAccumulator * futureMultipliers[i];
+                currentAccumulator *= localValue;
+            }
+
+            // specific contribution map for this layer
+            Map<String, Float> layerContributions = globalMarginalContributions.computeIfAbsent(key, k -> new HashMap<>());
+            // scale local contributions
+            Map<String, Float> localContributions = fm.getMarginalContributions("Base");
+            for (Map.Entry<String, Float> contribution : localContributions.entrySet()) {
+                float globalContribution = contribution.getValue() * scaleForEntry;
+                layerContributions.put(contribution.getKey(), globalContribution);
+            }
+        }
+    }
+
+    public void callGlobalContributionCallbacks() {
+        for (Map.Entry<ApplyFloatModifiable, FloatModifiable> entry : modifiables.entrySet()) {
+            ApplyFloatModifiable key = entry.getKey();
+            FloatModifiable fm = entry.getValue();
+
+            Map<String, Float> contributions = globalMarginalContributions.get(key);
+            if (contributions != null && !contributions.isEmpty()) {
+                fm.callContributionCallbacks(contributions);
+            }
+        }
+    }
+
+    public Map<ApplyFloatModifiable, Map<String, Float>> getGlobalMarginalContributions() {
+        return globalMarginalContributions;
+    }
+
+    public FloatModifiable.FloatModifier addModifier(
+            int priority,
+            ApplyFloatModifiableType applyType,
+            FloatModifiable.ModifierType type,
+            String log,
+            float value,
+            int ticksLeft,
+            Consumer<Float> callback,
+            boolean override
+    ) {
+        FloatModifiable floatModifiable = modifiables.computeIfAbsent(
+                new ApplyFloatModifiable(priority, applyType),
+                k -> new FloatModifiable(applyType == ApplyFloatModifiableType.MULTIPLICATIVE ? 1.0f : 0.0f)
+        );
+        return floatModifiable.addModifier(type, log, value, ticksLeft, callback, override);
+    }
+
+    public FloatModifiable.FloatModifier addModifier(int priority, ApplyFloatModifiableType applyType, FloatModifiable.ModifierType type, String log, float value) {
+        FloatModifiable floatModifiable = modifiables.computeIfAbsent(
+                new ApplyFloatModifiable(priority, applyType),
+                k -> new FloatModifiable(applyType == ApplyFloatModifiableType.MULTIPLICATIVE ? 1.0f : 0.0f)
+        );
+        return floatModifiable.addModifier(type, log, value);
+    }
+
+    public FloatModifiable.FloatModifier addModifier(int priority, ApplyFloatModifiableType applyType, FloatModifiable.ModifierType type, String log, float value, int ticksLeft) {
+        FloatModifiable floatModifiable = modifiables.computeIfAbsent(
+                new ApplyFloatModifiable(priority, applyType),
+                k -> new FloatModifiable(applyType == ApplyFloatModifiableType.MULTIPLICATIVE ? 1.0f : 0.0f)
+        );
+        return floatModifiable.addModifier(type, log, value, ticksLeft);
+    }
+
+    public FloatModifiable.FloatModifier addModifier(
+            int priority,
+            ApplyFloatModifiableType applyType,
+            FloatModifiable.ModifierType type,
+            String log,
+            float value,
+            Consumer<Float> callback
+    ) {
+        FloatModifiable floatModifiable = modifiables.computeIfAbsent(
+                new ApplyFloatModifiable(priority, applyType),
+                k -> new FloatModifiable(applyType == ApplyFloatModifiableType.MULTIPLICATIVE ? 1.0f : 0.0f)
+        );
+        return floatModifiable.addModifier(type, log, value, callback);
+    }
+
+    public Map<ApplyFloatModifiable, FloatModifiable> getModifiables() {
+        return modifiables;
+    }
+
+    public enum ApplyFloatModifiableType {
+        ADDITIVE,
+        MULTIPLICATIVE
+    }
+
+    public record ApplyFloatModifiable(int priority, ApplyFloatModifiableType applyType) {
+
+    }
+
+}

--- a/src/main/java/com/ebicep/warlords/util/warlords/modifiablevalues/MultiFloatModifiable.java
+++ b/src/main/java/com/ebicep/warlords/util/warlords/modifiablevalues/MultiFloatModifiable.java
@@ -1,5 +1,6 @@
 package com.ebicep.warlords.util.warlords.modifiablevalues;
 
+import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.function.Consumer;
 
@@ -12,6 +13,7 @@ public class MultiFloatModifiable implements Modifiable {
     );
     private final FloatModifiable baseModifiable;
     private final Map<ApplyFloatModifiable, Map<String, Float>> globalMarginalContributions = new HashMap<>();
+    private final Map<Consumer<FloatModifiable.FloatModifier>, FloatModifiable.ModifierType[]> onAddModifiers = new HashMap<>(2);
 
     public MultiFloatModifiable(FloatModifiable baseModifiable) {
         this.baseModifiable = baseModifiable;
@@ -68,6 +70,7 @@ public class MultiFloatModifiable implements Modifiable {
 
     @Override
     public void addModifierListener(Consumer<FloatModifiable.FloatModifier> consumer, FloatModifiable.ModifierType... modifierTypes) {
+        onAddModifiers.put(consumer, modifierTypes);
         for (FloatModifiable value : modifiables.values()) {
             value.addModifierListener(consumer, modifierTypes);
         }
@@ -75,6 +78,7 @@ public class MultiFloatModifiable implements Modifiable {
 
     @Override
     public void removeModifierListener(Consumer<FloatModifiable.FloatModifier> consumer, FloatModifiable.ModifierType... modifierTypes) {
+        onAddModifiers.remove(consumer);
         for (FloatModifiable value : modifiables.values()) {
             value.removeModifierListener(consumer, modifierTypes);
         }
@@ -166,15 +170,22 @@ public class MultiFloatModifiable implements Modifiable {
     ) {
         FloatModifiable floatModifiable = modifiables.computeIfAbsent(
                 new ApplyFloatModifiable(priority, applyType),
-                k -> new FloatModifiable(applyType == ApplyFloatModifiableType.MULTIPLICATIVE ? 1.0f : 0.0f)
+                k -> createNewFloatModifiable(applyType)
         );
         return floatModifiable.addModifier(type, log, value, ticksLeft, callback, override);
+    }
+
+    @Nonnull
+    private FloatModifiable createNewFloatModifiable(ApplyFloatModifiableType applyType) {
+        FloatModifiable fm = new FloatModifiable(applyType == ApplyFloatModifiableType.MULTIPLICATIVE ? 1.0f : 0.0f);
+        onAddModifiers.forEach(fm::addModifierListener);
+        return fm;
     }
 
     public FloatModifiable.FloatModifier addModifier(int priority, ApplyFloatModifiableType applyType, FloatModifiable.ModifierType type, String log, float value) {
         FloatModifiable floatModifiable = modifiables.computeIfAbsent(
                 new ApplyFloatModifiable(priority, applyType),
-                k -> new FloatModifiable(applyType == ApplyFloatModifiableType.MULTIPLICATIVE ? 1.0f : 0.0f)
+                k -> createNewFloatModifiable(applyType)
         );
         return floatModifiable.addModifier(type, log, value);
     }
@@ -182,7 +193,7 @@ public class MultiFloatModifiable implements Modifiable {
     public FloatModifiable.FloatModifier addModifier(int priority, ApplyFloatModifiableType applyType, FloatModifiable.ModifierType type, String log, float value, int ticksLeft) {
         FloatModifiable floatModifiable = modifiables.computeIfAbsent(
                 new ApplyFloatModifiable(priority, applyType),
-                k -> new FloatModifiable(applyType == ApplyFloatModifiableType.MULTIPLICATIVE ? 1.0f : 0.0f)
+                k -> createNewFloatModifiable(applyType)
         );
         return floatModifiable.addModifier(type, log, value, ticksLeft);
     }
@@ -197,7 +208,7 @@ public class MultiFloatModifiable implements Modifiable {
     ) {
         FloatModifiable floatModifiable = modifiables.computeIfAbsent(
                 new ApplyFloatModifiable(priority, applyType),
-                k -> new FloatModifiable(applyType == ApplyFloatModifiableType.MULTIPLICATIVE ? 1.0f : 0.0f)
+                k -> createNewFloatModifiable(applyType)
         );
         return floatModifiable.addModifier(type, log, value, callback);
     }


### PR DESCRIPTION
There are now levels to modifiers. Instead of one FloatModifiable being applied to damage value, there are multiple levels that can be applied. Levels are indicated by priority number, highest applied first. Levels are either added or multiplied together which happens sequentially based on priority number. Base level/priority is 100.

Example:
`
currentDamageValue.addModifier(50, MultiFloatModifiable.ApplyFloatModifiableType.ADDITIVE, FloatModifiable.ModifierType.ADDITIVE,
        "Avenger's Slash", DamageCheck.clamp(event.getWarlordsEntity().getMaxHealth() * 0.005f)
);
`

This is applied after priority 100 (base), and is MultiFloatModifiable.ApplyFloatModifiableType.ADDITIVE, so the calculated value gets added on top of base.