### PR TITLE
Made changes to the following boosts:

### DIFF
--- a/config/ABILITIES.json
+++ b/config/ABILITIES.json
@@ -1532,7 +1532,7 @@
         "name": "Time Surge",
         "cooldown": 28,
         "energyCost": 30,
-        "healPercentage": 30
+        "healPercentage": 35
       },
       "timeWarpAquamancer": {
         "name": "Time Warp",

--- a/config/SPEC_BOOSTS.json
+++ b/config/SPEC_BOOSTS.json
@@ -14,10 +14,11 @@
       "flameBreath": {
         "difficulty": 4,
         "name": "Shotgun Pyro",
-        "description": "Replace {{aqua:Flame Burst}} with {{aqua:Flame Breath}}. Replace {{aqua:Time Warp}} with {{aqua:Time Surge}}.",
+        "description": "Replace {{aqua:Flame Burst}} with {{aqua:Flame Breath}}, which has 2 charges. Replace {{aqua:Time Warp}} with {{aqua:Time Surge}}.",
         "cooldownReductionPercent": 30,
         "energyCostReductionPercent": 50,
-        "damageIncrease": -10
+        "damageIncrease": -10,
+        "maxAbilityCharges": 2
       },
       "burstChain": {
         "difficulty": 2,
@@ -100,9 +101,9 @@
         "difficulty": 1,
         "name": "Chilly Aura",
         "description": "{{aqua:Ice Barrier}} now slows enemies within {{blocks}} by {{speed;%}} and deals {{damage;%}} of their maximum health every {{ticks}}. Ice Barrier reduces melee attackers' speed by an additional {{speed;%}}.",
-        "rangeBlocks": 6,
+        "rangeBlocks": 8,
         "slowAmountPercent": 15,
-        "healthLossPercent": 1.5,
+        "healthLossPercent": 3,
         "healthLossTickPeriod": 20,
         "meleeSpeedReductionPercent": 30
       },
@@ -144,7 +145,7 @@
       "divinePurification": {
         "difficulty": 1,
         "name": "Divine Purification",
-        "description": "{{aqua:Water Breath}} now cleanses strong debuffs and grants those healed immunity to all debuffs for {{ticks}}, and reduce its cooldown by {{ticks;%}} and the energy cost by {{energy;%}}. {{aqua:Arcane Shield}} costs {{energy}} energy.",
+        "description": "{{aqua:Water Breath}} now cleanses strong debuffs and grants those healed immunity to all debuffs for {{ticks}}. Reduce its cooldown by {{ticks;%}} and the energy cost by {{energy;%}}. {{aqua:Arcane Shield}} costs {{energy}} energy.",
         "waterBreathImmunityDurationTicks": 20,
         "waterBreathCooldownReductionPercent": 15,
         "waterBreathEnergyCostReductionPercent": 50,
@@ -203,36 +204,33 @@
       "mightyFists": {
         "difficulty": 3,
         "name": "Mighty Fists",
-        "description": "Increase the wounding inflicted by {{aqua:Wounding Strike}} by {{damage;%}}. Each consecutive strike on a target increases the wounding by an additional {{damage;%}}, up to {{damage;%}}. While {{aqua:Berserk}} is active, {{aqua:Seismic Wave}} and {{aqua:Ground Slam}} inflict {{damage;%}} wounding for {{ticks}}.",
-        "woundingIncreasePercent": 10,
-        "consecutiveStrikeWoundingIncreasePercent": 5,
-        "maxConsecutiveStrikeWoundingIncreasePercent": 60,
-        "seismicWaveGroundSlamWoundingPercent": 30,
-        "seismicWaveGroundSlamWoundingDurationTicks": 60
+        "description": "Increase melee damage by {{damage;%}}. Every melee hit increases damage by another {{damage;%}}, up to {{damage;%}}. Activating any ability resets the bonus damage.",
+        "baseMeleePercent": 10,
+        "consecutiveHitIncreasePercent": 10,
+        "maxIncreasePercent": 50
       },
       "seismicShift": {
         "difficulty": 2,
         "name": "Seismic Shift",
         "description": "Reduce the cooldown of {{aqua:Seismic Wave}} by {{ticks}} and it now applies {{damage;%}} wounding for {{ticks}}.",
         "seismicWaveCooldownReductionTicks": 50,
-        "seismicWaveWoundingPercent": 40,
+        "seismicWaveWoundingPercent": 60,
         "seismicWaveWoundingTickDuration": 60
       },
       "bloodFrenzy": {
         "difficulty": 4,
         "name": "Blood Frenzy",
-        "description": "Reduce the cooldown of {{aqua:Bloodlust}} by {{ticks}}, the duration by {{ticks}}, and the energy cost by {{energy}}. Reduce its damage converted to healing by {{heal;%}} but it now heals an additional {{heal;%}} based on damage before any reductions. {{aqua:Berserk}} resets the cooldown of {{aqua:Bloodlust}}.",
+        "description": "Reduce the cooldown of {{aqua:Bloodlust}} by {{ticks}}, the duration by {{ticks}}, and the energy cost by {{energy}}. Heals an additional {{heal;%}} based on damage before any reductions. {{aqua:Berserk}} resets the cooldown of {{aqua:Bloodlust}}.",
         "bloodLustCooldownReductionTicks": 400,
-        "bloodLustDurationReductionTicks": 180,
+        "bloodLustDurationReductionTicks": 140,
         "bloodLustEnergyCostReduction": 20,
-        "bloodLustHealingPercent": 20,
-        "bloodLustHealingPiercePercent": 25
+        "bloodLustHealingPiercePercent": 10
       },
       "goliath": {
         "difficulty": 2,
         "name": "Goliath",
         "description": "Gain {{heal}} max health and {{energy}} max energy. Increase the cooldown of {{aqua:Berserk}} by {{ticks}}; it heals you for {{heal}} true healing upon activation.",
-        "healthIncrease": 1200,
+        "healthIncrease": 800,
         "maxEnergyIncrease": 100,
         "berserkCooldownIncreaseTicks": 360,
         "berserkActivationHeal": 1800
@@ -242,7 +240,7 @@
         "name": "Vitality Boost",
         "description": "Gain {{heal}} max health. Passively regenerate {{heal}} health per second, stacks with natural regen.",
         "healthIncrease": 600,
-        "passiveRegen": 30
+        "passiveRegen": 60
       },
       "striker": {
         "difficulty": 1,
@@ -261,9 +259,8 @@
       "heroicIntervention": {
         "difficulty": 1,
         "name": "Heroic Intervention",
-        "description": "Increase the max damage redirected by {{aqua:Intervene}} by {{damageReduction;}}, the duration by {{ticks}}, and the cast and break range by {{blocks}}.",
+        "description": "Increase the max damage redirected by {{aqua:Intervene}} by {{damageReduction;}}, and the cast and break range by {{blocks}}.",
         "interveneCapIncrease": 1100,
-        "interveneDurationIncreaseTicks": 20,
         "interveneCastAndRangeIncrease": 8
       },
       "solitary": {
@@ -332,22 +329,19 @@
         "name": "Unstoppable Surge",
         "description": "{{aqua:Light Infusion}} heals you for {{heal}} health, increase the speed granted by {{speed;%}} and the duration by {{ticks}}. Heal an additional {{heal}} health if Avenger's Strike was not used for {{ticks}} after activating Light Infusion. Gain permanent {{speed;%}} slow resistance and {{damageReduction;%}} knockback resistance.",
         "lightInfusionHealing": 800,
-        "lightInfusionSpeedIncreasePercent": 5,
+        "lightInfusionSpeedIncreasePercent": 15,
         "lightInfusionDurationIncreaseTicks": 40,
         "postLightInfusionHealing": 600,
         "postLightInfusionHealingDelay": 60,
         "slowResistancePercent": 15,
-        "knockbackResistancePercent": 20
+        "knockbackResistancePercent": 30
       },
       "markedForDeath": {
         "difficulty": 3,
         "name": "Marked for Death",
-        "description": "{{aqua:Avenger's Mark}} deals {{damage}} damage, slows by {{speed;%}}, and increases damage taken by {{damage;%}} for {{ticks}}. Each {{aqua:Avenger's Strike}} on the Marked target increases the duration of {{aqua:Avenger's Mark}} by {{ticks}}, up to {{ticks}}. Reduce the cooldown of {{aqua:Holy Radiance}} by {{ticks}} and the energy cost to {{energy}}.",
+        "description": "{{aqua:Avenger's Mark}} deals {{damage}} damage and slows by {{speed;%}}. Each {{aqua:Avenger's Strike}} on the Marked target increases the duration of {{aqua:Avenger's Mark}} by {{ticks}}, up to {{ticks}}. Remove the energy cost of {{aqua:Holy Radiance}}.",
         "avengerMarkDamage": 100,
         "avengerMarkSlowPercent": 10,
-        "avengerMarkIncreaseDamagePercent": 10,
-        "holyRadianceCooldownReductionTicks": 40,
-        "holyRadianceEnergyCost": 0,
         "strikeMarkDurationIncreaseTicks": 20,
         "maxStrikeMarkDurationIncreaseTicks": 60,
         "avengerMarkDebuffTickDuration": 100
@@ -364,7 +358,7 @@
         "difficulty": 1,
         "name": "Crusader's Might",
         "description": "Increase the damage of {{aqua:Crusader's Strike}} by {{damage;%}}.",
-        "damageIncreasePercent": 25
+        "damageIncreasePercent": 30
       },
       "parry": {
         "difficulty": 4,
@@ -415,18 +409,18 @@
         "difficulty": 1,
         "name": "Eco Drive",
         "description": "Reduce the cooldown of {{aqua:Light Infusion}} by {{ticks}}. Reduce the energy cost of {{aqua:Holy Radiance}} by {{energy}}. If {{aqua:Protector's Strike}} heals only one ally, you are both healed for an additional {{heal;%}}.",
-        "lightInfusionCooldownReductionTicks": 50,
+        "lightInfusionCooldownReductionTicks": 70,
         "holyRadianceEnergyCost": 40,
-        "singleAllyHealBonusPercent": 20
+        "singleAllyHealBonusPercent": 40
       },
       "divineEffulgence": {
         "difficulty": 3,
         "name": "Divine Effulgence",
-        "description": "Increase the healing of {{aqua:Holy Radiance}} by {{heal;%}} and the travel speed by {{speed;%}}. Allies healed by {{aqua:Holy Radiance}} gain {{damageReduction;%}} damage reduction against ranged damage for {{ticks}}.",
+        "description": "Increase the healing of {{aqua:Holy Radiance}} by {{heal;%}} and the travel speed by {{speed;%}}. Allies healed by {{aqua:Holy Radiance}} gain {{damageReduction;%}} damage reduction against primary abilities for {{ticks}}.",
         "holyRadianceHealingIncreasePercent": 20,
         "holyRadianceTravelSpeedPercentIncrease": 200,
-        "rangedDamageReductionPercent": 30,
-        "rangedDamageReductionDurationTicks": 60
+        "primaryAbilityDamageReductionPercent": 20,
+        "primaryAbilityDamageReductionDurationTicks": 60
       },
       "lustrousCrown": {
         "difficulty": 1,
@@ -470,19 +464,19 @@
         "windfuryExtraGuaranteedHits": 1,
         "slowKbResistancePercent": 100,
         "speedIncreasePercent": 40,
-        "speedDurationTicks": 40
+        "speedDurationTicks": 80
       },
       "galvanizedSpark": {
         "difficulty": 2,
         "name": "Galvanized Spark",
-        "description": "Increase the charges of {{aqua:Lightning Rod}} to {{blue}}, reduce the cooldown by {{ticks}}, the healing by {{heal;%}}, the energy granted by {{energy}}, and the knockback inflicted. {{aqua:Lightning Rod}} resets the cooldown of {{aqua:Chain Lightning}} and grants {{speed;%}} speed for {{ticks}}. Reduce the damage of {{aqua:Capacitor Totem}} by {{damage}}.",
+        "description": "Increase the charges of {{aqua:Lightning Rod}} to {{blue}}, reduce the cooldown by {{ticks}}, the healing by {{heal;%}}, the energy granted by {{energy}}, and the knockback inflicted. {{aqua:Lightning Rod}} resets the cooldown of {{aqua:Chain Lightning}} and grants {{speed;%}} speed for {{ticks}}. Reduce the damage of {{aqua:Capacitor Totem}} by {{damage;%}}.",
         "lightningRodMaxAbilityCharges": 2,
         "lightningRodCooldownDecreaseSeconds": 16.5,
         "lightningRodHealingDecreasePercent": 5,
         "lightningRodEnergyRestoreDecrease": 120,
-        "lightningRodSpeedIncreasePercent": 70,
+        "lightningRodSpeedIncreasePercent": 60,
         "lightningRodSpeedDurationTicks": 20,
-        "capacitorTotemDamageDecreasePercent": 15,
+        "capacitorTotemDamageDecreasePercent": 20,
         "lightningRodMagnitude": 1.25,
         "lightningRodY": 0.3
       },
@@ -490,7 +484,7 @@
         "difficulty": 4,
         "name": "Eye of the Storm",
         "description": "Reduce the range of {{aqua:Lightning Bolt}} to {{blocks}}, but increase the speed by {{speed;%}} and it will violently explode upon expiration or ground contact, with a {{blocks}} splash radius. Increase the {{aqua:Chain Lightning}} cooldown reduction from {{aqua:Lightning Bolt}} by {{ticks}}. {{aqua:Capacitor Totem}} can be casted to where you are looking (up to {{blocks}}), instantly procs on cast, and {{aqua:Lightning Rod}} always procs it.",
-        "maxTravelBlocks": 10,
+        "maxTravelBlocks": 15,
         "velocityIncreasePercentage": 100,
         "splashRadiusBlocks": 4,
         "chainCooldownReductionIncrease": 0.5,
@@ -534,8 +528,8 @@
         "maxEnergyIncrease": 50,
         "travelSpeedIncreasePercent": 50,
         "castRangeIncrease": 10,
-        "hitRadiusIncrease": 3.5,
-        "damageIncreasePercent": 25
+        "hitRadiusIncrease": 2,
+        "damageIncreasePercent": 40
       },
       "megalithicBoulder": {
         "difficulty": 1,
@@ -742,8 +736,9 @@
       "witheringPlague": {
         "difficulty": 3,
         "name": "Withering Plague",
-        "description": "For the duration of {{aqua:Astral Plague}}, increase the damage dealt to non-Tank enemies with max stacks of {{dark_red:PHEX}} by {{damage;%}}.",
-        "damageIncrease": 30
+        "description": "For the duration of {{aqua:Astral Plague}}, increase the damage dealt to non-Tank enemies with max stacks of {{dark_red:PHEX}} by {{damage;%}} and increase its damaging ticks by {{blue}}.",
+        "damageIncrease": 30,
+        "poisonousHexDamagingTicksIncrease": 2
       },
       "airStrike": {
         "difficulty": 5,
@@ -855,10 +850,11 @@
       "holyNova": {
         "difficulty": 3,
         "name": "Holy Nova",
-        "description": "{{aqua:Divine Blessing}} heals allies more than {{blocks}} from you for an additional {{heal;%}} and deals {{damage}} damage to all enemies as it heals.",
+        "description": "{{aqua:Divine Blessing}} heals allies more than {{blocks}} from you for an additional {{heal;%}} and deals {{damage}} damage the closest {{blue}} enemies as it heals.",
         "divineBlessingFarRangeBlocks": 50,
         "divineBlessingHealingIncreasePercentFar": 50,
-        "divineBlessingDamageToEnemies": 400
+        "divineBlessingDamageToEnemies": 400,
+        "divineBlessingEnemiesHit": 5
       }
     }
   }

--- a/config/SPEC_BOOSTS.json
+++ b/config/SPEC_BOOSTS.json
@@ -736,9 +736,9 @@
       "witheringPlague": {
         "difficulty": 3,
         "name": "Withering Plague",
-        "description": "For the duration of {{aqua:Astral Plague}}, increase the damage dealt to non-Tank enemies with max stacks of {{dark_red:PHEX}} by {{damage;%}} and increase phex duration by {{ticks}}.",
+        "description": "Increase the duration of {{dark_red:PHEX}} by {{ticks}}. For the duration of {{aqua:Astral Plague}}, increase the damage dealt to non-Tank enemies with max stacks of {{dark_red:PHEX}} by {{damage;%}}.",
+        "poisonousHexTicksIncrease": 80,
         "damageIncrease": 30,
-        "poisonousHexTicksIncrease": 80
       },
       "airStrike": {
         "difficulty": 5,

--- a/config/SPEC_BOOSTS.json
+++ b/config/SPEC_BOOSTS.json
@@ -220,11 +220,11 @@
       "bloodFrenzy": {
         "difficulty": 4,
         "name": "Blood Frenzy",
-        "description": "Reduce the cooldown of {{aqua:Bloodlust}} by {{ticks}}, the duration by {{ticks}}, and the energy cost by {{energy}}. Heals an additional {{heal;%}} based on damage before any reductions. {{aqua:Berserk}} resets the cooldown of {{aqua:Bloodlust}}.",
-        "bloodLustCooldownReductionTicks": 400,
+        "description": "Reduce the cooldown of {{aqua:Bloodlust}} by {{ticks}}, the duration by {{ticks}}, and the energy cost by {{energy}}. Reduce its damage converted to healing by {{heal;%}} but it now heals an additional {{heal;%}} based on damage before any reductions. {{aqua:Berserk}} resets the cooldown of {{aqua:Bloodlust}}.",        "bloodLustCooldownReductionTicks": 400,
         "bloodLustDurationReductionTicks": 140,
         "bloodLustEnergyCostReduction": 20,
-        "bloodLustHealingPiercePercent": 10
+        "bloodLustHealingPercent": 15,
+        "bloodLustHealingPiercePercent": 25
       },
       "goliath": {
         "difficulty": 2,
@@ -736,9 +736,9 @@
       "witheringPlague": {
         "difficulty": 3,
         "name": "Withering Plague",
-        "description": "For the duration of {{aqua:Astral Plague}}, increase the damage dealt to non-Tank enemies with max stacks of {{dark_red:PHEX}} by {{damage;%}} and increase its damaging ticks by {{blue}}.",
+        "description": "For the duration of {{aqua:Astral Plague}}, increase the damage dealt to non-Tank enemies with max stacks of {{dark_red:PHEX}} by {{damage;%}} and increase phex duration by {{ticks}}.",
         "damageIncrease": 30,
-        "poisonousHexDamagingTicksIncrease": 2
+        "poisonousHexTicksIncrease": 80
       },
       "airStrike": {
         "difficulty": 5,

--- a/src/main/java/com/ebicep/warlords/abilities/FlameBreath.java
+++ b/src/main/java/com/ebicep/warlords/abilities/FlameBreath.java
@@ -99,7 +99,7 @@ public class FlameBreath extends AbstractAbility implements RedAbilityIcon, Dama
     public void updateDescription(Player player) {
         description = AbilityDescriptionBuilder.create("Breathe flames in a cone in front of you, knocking back enemies, dealing ")
                                                .damage(damageValues.flameBreathDamage)
-                                               .text(" damage to enemies hit.")
+                                               .text(" damage to enemies hit. ")
                                                .build();
     }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BloodFrenzy.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BloodFrenzy.java
@@ -20,6 +20,7 @@ public class BloodFrenzy implements SpecBoostManager.SpecBoost<BloodFrenzy> {
     private int bloodLustCooldownReductionTicks;
     private int bloodLustDurationReductionTicks;
     private int bloodLustEnergyCostReduction;
+    private float bloodLustHealingPercent;
     private float bloodLustHealingPiercePercent;
 
     @Override
@@ -27,6 +28,7 @@ public class BloodFrenzy implements SpecBoostManager.SpecBoost<BloodFrenzy> {
         this.bloodLustCooldownReductionTicks = getValue("bloodLustCooldownReductionTicks", int.class);
         this.bloodLustDurationReductionTicks = getValue("bloodLustDurationReductionTicks", int.class);
         this.bloodLustEnergyCostReduction = getValue("bloodLustEnergyCostReduction", int.class);
+        this.bloodLustHealingPercent = getValue("bloodLustHealingPercent", float.class);
         this.bloodLustHealingPiercePercent = getValue("bloodLustHealingPiercePercent", float.class);
     }
 
@@ -37,7 +39,7 @@ public class BloodFrenzy implements SpecBoostManager.SpecBoost<BloodFrenzy> {
 
     @Override
     public List<Object> getVariables() {
-        return List.of(bloodLustCooldownReductionTicks, bloodLustDurationReductionTicks, bloodLustEnergyCostReduction, bloodLustHealingPiercePercent);
+        return List.of(bloodLustCooldownReductionTicks, bloodLustDurationReductionTicks, bloodLustEnergyCostReduction, bloodLustHealingPercent, bloodLustHealingPiercePercent);
     }
 
     @Override
@@ -61,6 +63,7 @@ public class BloodFrenzy implements SpecBoostManager.SpecBoost<BloodFrenzy> {
                 bloodLust.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -bloodLustCooldownReductionTicks / 20f);
                 bloodLust.setTickDuration(bloodLust.getTickDuration() - bloodLustDurationReductionTicks);
                 bloodLust.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -bloodLustEnergyCostReduction);
+                bloodLust.setDamageConvertPercent(bloodLust.getDamageConvertPercent() - (int) bloodLustHealingPercent);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BloodFrenzy.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BloodFrenzy.java
@@ -20,7 +20,6 @@ public class BloodFrenzy implements SpecBoostManager.SpecBoost<BloodFrenzy> {
     private int bloodLustCooldownReductionTicks;
     private int bloodLustDurationReductionTicks;
     private int bloodLustEnergyCostReduction;
-    private float bloodLustHealingPercent;
     private float bloodLustHealingPiercePercent;
 
     @Override
@@ -28,7 +27,6 @@ public class BloodFrenzy implements SpecBoostManager.SpecBoost<BloodFrenzy> {
         this.bloodLustCooldownReductionTicks = getValue("bloodLustCooldownReductionTicks", int.class);
         this.bloodLustDurationReductionTicks = getValue("bloodLustDurationReductionTicks", int.class);
         this.bloodLustEnergyCostReduction = getValue("bloodLustEnergyCostReduction", int.class);
-        this.bloodLustHealingPercent = getValue("bloodLustHealingPercent", float.class);
         this.bloodLustHealingPiercePercent = getValue("bloodLustHealingPiercePercent", float.class);
     }
 
@@ -39,7 +37,7 @@ public class BloodFrenzy implements SpecBoostManager.SpecBoost<BloodFrenzy> {
 
     @Override
     public List<Object> getVariables() {
-        return List.of(bloodLustCooldownReductionTicks, bloodLustDurationReductionTicks, bloodLustEnergyCostReduction, bloodLustHealingPercent, bloodLustHealingPiercePercent);
+        return List.of(bloodLustCooldownReductionTicks, bloodLustDurationReductionTicks, bloodLustEnergyCostReduction, bloodLustHealingPiercePercent);
     }
 
     @Override
@@ -63,7 +61,6 @@ public class BloodFrenzy implements SpecBoostManager.SpecBoost<BloodFrenzy> {
                 bloodLust.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -bloodLustCooldownReductionTicks / 20f);
                 bloodLust.setTickDuration(bloodLust.getTickDuration() - bloodLustDurationReductionTicks);
                 bloodLust.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -bloodLustEnergyCostReduction);
-                bloodLust.setDamageConvertPercent(bloodLust.getDamageConvertPercent() - (int) bloodLustHealingPercent);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/DivineEffulgence.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/DivineEffulgence.java
@@ -17,26 +17,17 @@ import java.util.List;
 
 public class DivineEffulgence implements SpecBoostManager.SpecBoost<DivineEffulgence> {
 
-    public static boolean isCustomProjectile(String cause) {
-        return cause.equals("Chain Lightning") ||
-                cause.equals("Spirit Link") ||
-                cause.equals("Soulfire Beam") ||
-                cause.equals("Guardian Beam") ||
-                cause.equals("Ray of Light") ||
-                cause.equals("Incendiary Curse") ||
-                cause.equals("Boulder");
-    }
     private float holyRadianceHealingIncreasePercent;
     private float holyRadianceTravelSpeedPercentIncrease;
-    private float rangedDamageReductionPercent;
-    private int rangedDamageReductionDurationTicks;
+    private float primaryAbilityDamageReductionPercent;
+    private int primaryAbilityDamageReductionDurationTicks;
 
     @Override
     public void init() {
         this.holyRadianceHealingIncreasePercent = getValue("holyRadianceHealingIncreasePercent", float.class);
         this.holyRadianceTravelSpeedPercentIncrease = getValue("holyRadianceTravelSpeedPercentIncrease", float.class);
-        this.rangedDamageReductionPercent = getValue("rangedDamageReductionPercent", float.class);
-        this.rangedDamageReductionDurationTicks = getValue("rangedDamageReductionDurationTicks", int.class);
+        this.primaryAbilityDamageReductionPercent = getValue("primaryAbilityDamageReductionPercent", float.class);
+        this.primaryAbilityDamageReductionDurationTicks = getValue("primaryAbilityDamageReductionDurationTicks", int.class);
     }
 
     @Override
@@ -46,7 +37,7 @@ public class DivineEffulgence implements SpecBoostManager.SpecBoost<DivineEffulg
 
     @Override
     public List<Object> getVariables() {
-        return List.of(holyRadianceHealingIncreasePercent, holyRadianceTravelSpeedPercentIncrease, rangedDamageReductionPercent, rangedDamageReductionDurationTicks);
+        return List.of(holyRadianceHealingIncreasePercent, holyRadianceTravelSpeedPercentIncrease, primaryAbilityDamageReductionPercent, primaryAbilityDamageReductionDurationTicks);
     }
 
     @Override
@@ -93,12 +84,12 @@ public class DivineEffulgence implements SpecBoostManager.SpecBoost<DivineEffulg
                     warlordsEntity,
                     CooldownTypes.SPEC_BOOST,
                     cooldownManager -> {},
-                    rangedDamageReductionDurationTicks
+                    primaryAbilityDamageReductionDurationTicks
             ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE, (e, currentDamageValue) -> {
-                        if (Utils.isProjectile(e.getCause()) || isCustomProjectile(e.getCause())) {
+                        if (Utils.isStrikeSlashSpike(e.getCause()) || Utils.isPrimaryProjectile(e.getCause())) {
                             currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLIER,
                                     getStringName(),
-                                    AbstractAbility.convertToDivisionDecimal(rangedDamageReductionPercent)
+                                    AbstractAbility.convertToDivisionDecimal(primaryAbilityDamageReductionPercent)
                             );
                         }
                     }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Downpour.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Downpour.java
@@ -76,6 +76,8 @@ public class Downpour implements SpecBoostManager.SpecBoost<Downpour> {
                 );
                 healingRain.setTickDuration(Math.round(healingRain.getTickDuration() * (1 - healingRainDurationDecreasePercent / 100)));
                 healingRain.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -healingRainRadiusDecreaseBlocks);
+                healingRain.setCurrentCooldown(0);
+                healingRain.setCurrentCooldown(0);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/FlameBreath.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/FlameBreath.java
@@ -12,8 +12,11 @@ import java.util.List;
 
 public class FlameBreath implements SpecBoostManager.SpecBoost<FlameBreath> {
 
+    private int maxAbilityCharges;
+
     @Override
     public void init() {
+        this.maxAbilityCharges = getValue("maxAbilityCharges", int.class);
     }
 
     @Override
@@ -31,7 +34,7 @@ public class FlameBreath implements SpecBoostManager.SpecBoost<FlameBreath> {
 
     @Override
     public List<Object> getVariables() {
-        return List.of();
+        return List.of(maxAbilityCharges);
     }
 
     @Override
@@ -55,7 +58,9 @@ public class FlameBreath implements SpecBoostManager.SpecBoost<FlameBreath> {
             for (int i = 0; i < abilities.size(); i++) {
                 if (abilities.get(i) instanceof FlameBurst) {
                     com.ebicep.warlords.abilities.FlameBreath flameBreath = new com.ebicep.warlords.abilities.FlameBreath();
+                    flameBreath.setMaxCharges(maxAbilityCharges);
                     flameBreath.init(flameBreath.getBuilder());
+                    flameBreath.setCurrentCooldown(1);
                     abilities.set(i, flameBreath);
                 } else if (abilities.get(i) instanceof TimeWarpPyromancer) {
                     TimeSurge timeSurge = new TimeSurge();

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/HolyNova.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/HolyNova.java
@@ -21,12 +21,14 @@ public class HolyNova implements SpecBoostManager.SpecBoost<HolyNova> {
     private float divineBlessingFarRangeBlocks;
     private float divineBlessingHealingIncreasePercentFar;
     private int divineBlessingDamageToEnemies;
+    private int divineBlessingEnemiesHit;
 
     @Override
     public void init() {
         this.divineBlessingFarRangeBlocks = getValue("divineBlessingFarRangeBlocks", float.class);
         this.divineBlessingHealingIncreasePercentFar = getValue("divineBlessingHealingIncreasePercentFar", float.class);
         this.divineBlessingDamageToEnemies = getValue("divineBlessingDamageToEnemies", int.class);
+        this.divineBlessingEnemiesHit = getValue("divineBlessingEnemiesHit", int.class);
     }
 
     @Override
@@ -39,7 +41,8 @@ public class HolyNova implements SpecBoostManager.SpecBoost<HolyNova> {
         return List.of(
                 divineBlessingFarRangeBlocks,
                 divineBlessingHealingIncreasePercentFar,
-                divineBlessingDamageToEnemies
+                divineBlessingDamageToEnemies,
+                divineBlessingEnemiesHit
         );
     }
 
@@ -87,7 +90,7 @@ public class HolyNova implements SpecBoostManager.SpecBoost<HolyNova> {
             );
             regularCooldown.addTriConsumer((cd, ticksLeft, ticksElapsed) -> {
                 if (ticksElapsed == data.getDivineBlessing().getPostHealthTickDelay()) {
-                    PlayerFilter.playingGame(warlordsEntity.getGame()).aliveEnemiesOf(warlordsEntity).forEach(teammate -> {
+                    PlayerFilter.playingGame(warlordsEntity.getGame()).aliveEnemiesOf(warlordsEntity).closestFirst(warlordsEntity).limit(divineBlessingEnemiesHit).forEach(teammate -> {
                         teammate.playSound(teammate.getLocation(), "shaman.earthlivingweapon.impact", 1, 0.55f);
                         teammate.playSound(teammate.getLocation(), "arcanist.divineblessing.impact", 0.2f, 1.75f);
                         teammate.addInstance(InstanceBuilder

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MarkedForDeath.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MarkedForDeath.java
@@ -2,7 +2,6 @@ package com.ebicep.warlords.player.general.specboosts.boosts;
 
 import com.ebicep.warlords.abilities.AvengersStrike;
 import com.ebicep.warlords.abilities.HolyRadianceAvenger;
-import com.ebicep.warlords.abilities.internal.AbstractAbility;
 import com.ebicep.warlords.events.player.ingame.WarlordsAddCooldownEvent;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
@@ -21,9 +20,7 @@ public class MarkedForDeath implements SpecBoostManager.SpecBoost<MarkedForDeath
 
     private float avengerMarkDamage;
     private float avengerMarkSlowPercent;
-    private float avengerMarkIncreaseDamagePercent;
     private int avengerMarkDebuffTickDuration;
-    private int holyRadianceCooldownReductionTicks;
     private float holyRadianceEnergyCost;
     private int strikeMarkDurationIncreaseTicks;
     private int maxStrikeMarkDurationIncreaseTicks;
@@ -32,9 +29,7 @@ public class MarkedForDeath implements SpecBoostManager.SpecBoost<MarkedForDeath
     public void init() {
         this.avengerMarkDamage = getValue("avengerMarkDamage", float.class);
         this.avengerMarkSlowPercent = getValue("avengerMarkSlowPercent", float.class);
-        this.avengerMarkIncreaseDamagePercent = getValue("avengerMarkIncreaseDamagePercent", float.class);
         this.avengerMarkDebuffTickDuration = getValue("avengerMarkDebuffTickDuration", int.class);
-        this.holyRadianceCooldownReductionTicks = getValue("holyRadianceCooldownReductionTicks", int.class);
         this.holyRadianceEnergyCost = getValue("holyRadianceEnergyCost", float.class);
         this.strikeMarkDurationIncreaseTicks = getValue("strikeMarkDurationIncreaseTicks", int.class);
         this.maxStrikeMarkDurationIncreaseTicks = getValue("maxStrikeMarkDurationIncreaseTicks", int.class);
@@ -75,7 +70,6 @@ public class MarkedForDeath implements SpecBoostManager.SpecBoost<MarkedForDeath
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(HolyRadianceAvenger.class).forEach(holyRadiance -> {
-                holyRadiance.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -holyRadianceCooldownReductionTicks / 20f);
                 holyRadiance.getEnergyCost().addModifier(FloatModifiable.ModifierType.OVERRIDING, "Spec Boost", holyRadianceEnergyCost);
             });
         }
@@ -99,13 +93,6 @@ public class MarkedForDeath implements SpecBoostManager.SpecBoost<MarkedForDeath
                     .value(100)
             );
             target.addSpeedModifier(warlordsEntity, getStringName(), -avengerMarkSlowPercent, regularCooldown);
-            regularCooldown.addModifier(Modifier.INCOMING_DAMAGE_BEFORE_INTERVENE, (e, currentDamageValue) -> {
-                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLIER,
-                        getStringName(),
-                        AbstractAbility.convertToMultiplicationDecimal(avengerMarkIncreaseDamagePercent)
-                );
-                    }
-            );
             final int[] ticksIncreased = {0};
             regularCooldown.addModifier(Modifier.ON_INCOMING_DAMAGE, (e, currentDamageValue, isCrit) -> {
                 if (e.getSource().equals(warlordsEntity) && e.getAbility() instanceof AvengersStrike) {

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MarkedForDeath.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MarkedForDeath.java
@@ -50,12 +50,10 @@ public class MarkedForDeath implements SpecBoostManager.SpecBoost<MarkedForDeath
         return List.of(
                 avengerMarkDamage,
                 avengerMarkSlowPercent,
-                avengerMarkIncreaseDamagePercent,
                 avengerMarkDebuffTickDuration,
                 strikeMarkDurationIncreaseTicks,
-                maxStrikeMarkDurationIncreaseTicks,
-                holyRadianceCooldownReductionTicks,
-                holyRadianceEnergyCost
+                maxStrikeMarkDurationIncreaseTicks
+
         );
     }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MightyFists.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MightyFists.java
@@ -83,13 +83,6 @@ public class MightyFists implements SpecBoostManager.SpecBoost<MightyFists> {
             if (!warlordsEntity.equals(event.getWarlordsEntity())) {
                 return;
             }
-            if (!(event.getAbility() instanceof WoundingStrikeBerserker ||
-                    event.getAbility() instanceof SeismicWaveBerserker ||
-                    event.getAbility() instanceof GroundSlamBerserker ||
-                    event.getAbility() instanceof BloodLust ||
-                    event.getAbility() instanceof Berserk)) {
-                return;
-            }
             meleeIncreasePercent = baseMeleePercent;
         }
 
@@ -98,7 +91,7 @@ public class MightyFists implements SpecBoostManager.SpecBoost<MightyFists> {
             if (!event.getSource().equals(warlordsEntity)) {
                 return;
             }
-            if (!event.getInstanceFlags().contains(InstanceFlags.NO_HIT_SOUND)){
+            if (event.isDamageInstance() && event.getCause().contains("melee")) {
                 return;
             }
             meleeIncreasePercent = Math.min(meleeIncreasePercent + consecutiveHitIncreasePercent, maxIncreasePercent);

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MightyFists.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MightyFists.java
@@ -1,13 +1,15 @@
 package com.ebicep.warlords.player.general.specboosts.boosts;
 
-import com.ebicep.warlords.abilities.Berserk;
-import com.ebicep.warlords.abilities.WoundingStrikeBerserker;
-import com.ebicep.warlords.abilities.internal.WoundingCooldown;
+import com.ebicep.warlords.abilities.*;
+import com.ebicep.warlords.events.player.ingame.WarlordsAbilityActivateEvent;
 import com.ebicep.warlords.events.player.ingame.WarlordsDamageHealingFinalEvent;
-import com.ebicep.warlords.events.player.ingame.WarlordsPlayerWoundedEvent;
 import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
 import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
+import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.PermanentCooldown;
+import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
+import com.ebicep.warlords.player.ingame.instances.type.Modifier;
 import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import org.bukkit.event.EventHandler;
 
@@ -15,19 +17,16 @@ import java.util.List;
 
 public class MightyFists implements SpecBoostManager.SpecBoost<MightyFists> {
 
-    private float woundingIncreasePercent;
-    private float consecutiveStrikeWoundingIncreasePercent;
-    private float maxConsecutiveStrikeWoundingIncreasePercent;
-    private float seismicWaveGroundSlamWoundingPercent;
-    private int seismicWaveGroundSlamWoundingDurationTicks;
+    private float meleeIncreasePercent;
+    private float baseMeleePercent;
+    private float consecutiveHitIncreasePercent;
+    private float maxIncreasePercent;
 
     @Override
     public void init() {
-        this.woundingIncreasePercent = getValue("woundingIncreasePercent", float.class);
-        this.consecutiveStrikeWoundingIncreasePercent = getValue("consecutiveStrikeWoundingIncreasePercent", float.class);
-        this.maxConsecutiveStrikeWoundingIncreasePercent = getValue("maxConsecutiveStrikeWoundingIncreasePercent", float.class);
-        this.seismicWaveGroundSlamWoundingPercent = getValue("seismicWaveGroundSlamWoundingPercent", float.class);
-        this.seismicWaveGroundSlamWoundingDurationTicks = getValue("seismicWaveGroundSlamWoundingDurationTicks", int.class);
+        this.baseMeleePercent = getValue("baseMeleePercent", float.class);
+        this.consecutiveHitIncreasePercent = getValue("consecutiveHitIncreasePercent", float.class);
+        this.maxIncreasePercent = getValue("maxIncreasePercent", float.class);
     }
 
     @Override
@@ -37,11 +36,9 @@ public class MightyFists implements SpecBoostManager.SpecBoost<MightyFists> {
 
     @Override
     public List<Object> getVariables() {
-        return List.of(woundingIncreasePercent,
-                consecutiveStrikeWoundingIncreasePercent,
-                maxConsecutiveStrikeWoundingIncreasePercent,
-                seismicWaveGroundSlamWoundingPercent,
-                seismicWaveGroundSlamWoundingDurationTicks
+        return List.of(baseMeleePercent,
+                consecutiveHitIncreasePercent,
+                maxIncreasePercent
         );
     }
 
@@ -62,10 +59,38 @@ public class MightyFists implements SpecBoostManager.SpecBoost<MightyFists> {
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
+            meleeIncreasePercent = baseMeleePercent;
+            warlordsPlayer.getCooldownManager().addCooldown(new PermanentCooldown<>(
+                    getStringName(),
+                    null,
+                    MightyFists.class,
+                    null,
+                    warlordsPlayer,
+                    CooldownTypes.SPEC_BOOST,
+                    cooldownManager -> {
 
-            warlordsPlayer.getAbilitiesMatching(WoundingStrikeBerserker.class).forEach(woundingStrike -> {
-                woundingStrike.getWounding().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", woundingIncreasePercent);
-            });
+                    },
+                    false
+            ).addModifier(Modifier.MODIFY_OUTGOING_DAMAGE_BEFORE_INTERVENE, (event, currentDamageValue) -> {
+                        if (event.getCause().isEmpty()) {
+                            currentDamageValue.addModifier(FloatModifiable.ModifierType.ADDITIVE_MULTIPLIER, getConfigFieldName(), meleeIncreasePercent / 100);
+                        }
+                    }
+            ));
+        }
+        @EventHandler
+        public void onWarlordsAbilityActivateEventPost(WarlordsAbilityActivateEvent.Post event) {
+            if (!warlordsEntity.equals(event.getWarlordsEntity())) {
+                return;
+            }
+            if (!(event.getAbility() instanceof WoundingStrikeBerserker ||
+                    event.getAbility() instanceof SeismicWaveBerserker ||
+                    event.getAbility() instanceof GroundSlamBerserker ||
+                    event.getAbility() instanceof BloodLust ||
+                    event.getAbility() instanceof Berserk)) {
+                return;
+            }
+            meleeIncreasePercent = baseMeleePercent;
         }
 
         @EventHandler
@@ -73,46 +98,11 @@ public class MightyFists implements SpecBoostManager.SpecBoost<MightyFists> {
             if (!event.getSource().equals(warlordsEntity)) {
                 return;
             }
-            if (!event.getCause().equals("Seismic Wave") && !event.getCause().equals("Ground Slam")) {
+            if (!event.getInstanceFlags().contains(InstanceFlags.NO_HIT_SOUND)){
                 return;
             }
-            if (!warlordsEntity.getCooldownManager().hasCooldown(Berserk.class)) {
-                return;
-            }
-            WarlordsEntity target = event.getWarlordsEntity();
-            WoundingCooldown.addWoundingCooldown(
-                    target,
-                    getStringName(),
-                    warlordsEntity,
-                    seismicWaveGroundSlamWoundingPercent,
-                    seismicWaveGroundSlamWoundingDurationTicks
-            );
+            meleeIncreasePercent = Math.min(meleeIncreasePercent + consecutiveHitIncreasePercent, maxIncreasePercent);
         }
-
-        @EventHandler
-        public void onPlayerWoundedEvent(WarlordsPlayerWoundedEvent event) {
-            if (!event.getFrom().equals(warlordsEntity)) {
-                return;
-            }
-            if (!event.getName().equals("Wounding Strike")) {
-                return;
-            }
-            WoundingCooldown woundingCooldown = event.getWoundingCooldown();
-            if (woundingCooldown == null) {
-                return;
-            }
-            WoundingCooldown.WoundingData woundingData = woundingCooldown.getCooldownObject();
-            for (WoundingCooldown.WoundingData.WoundingInstance instance : woundingData.instances()) {
-                if (instance.getFrom().equals(warlordsEntity) && instance.getName().equals("Wounding Strike")) {
-                    instance.setAmount(Math.min(maxConsecutiveStrikeWoundingIncreasePercent, instance.getAmount() + consecutiveStrikeWoundingIncreasePercent));
-                    instance.setTicksLeft(event.getTickDuration());
-                    woundingCooldown.updateTicksLeft();
-                    event.setCancelled(true);
-                    return;
-                }
-            }
-        }
-
     }
 
 }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MightyFists.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MightyFists.java
@@ -91,7 +91,10 @@ public class MightyFists implements SpecBoostManager.SpecBoost<MightyFists> {
             if (!event.getSource().equals(warlordsEntity)) {
                 return;
             }
-            if (event.isDamageInstance() && event.getCause().contains("melee")) {
+            if (!event.isDamageInstance()) {
+                return;
+            }
+            if (!event.getCause().isEmpty()) {
                 return;
             }
             meleeIncreasePercent = Math.min(meleeIncreasePercent + consecutiveHitIncreasePercent, maxIncreasePercent);

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/WitheringPlague.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/WitheringPlague.java
@@ -59,7 +59,7 @@ public class WitheringPlague implements SpecBoostManager.SpecBoost<WitheringPlag
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(PoisonousHex.class).forEach(poisonousHex -> {
-                poisonousHex.setTickDurationDot(poisonousHex.getTickDurationDot() + (poisonousHex.getTicksBetweenDot() * poisonousHexDamagingTicksIncrease));
+                poisonousHex.setTickDuration(poisonousHex.getTickDuration() + (poisonousHex.getTicksBetweenDot() * poisonousHexDamagingTicksIncrease));
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/WitheringPlague.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/WitheringPlague.java
@@ -20,12 +20,12 @@ import java.util.List;
 public class WitheringPlague implements SpecBoostManager.SpecBoost<WitheringPlague> {
 
     private float damageIncrease;
-    private int poisonousHexDamagingTicksIncrease;
+    private int poisonousHexTicksIncrease;
 
     @Override
     public void init() {
         this.damageIncrease = getValue("damageIncrease", float.class);
-        this.poisonousHexDamagingTicksIncrease = getValue("poisonousHexDamagingTicksIncrease", int.class);
+        this.poisonousHexTicksIncrease = getValue("poisonousHexTicksIncrease", int.class);
     }
 
     @Override
@@ -37,7 +37,7 @@ public class WitheringPlague implements SpecBoostManager.SpecBoost<WitheringPlag
     public List<Object> getVariables() {
         return List.of(
                 damageIncrease,
-                poisonousHexDamagingTicksIncrease
+                poisonousHexTicksIncrease
         );
     }
 
@@ -59,7 +59,7 @@ public class WitheringPlague implements SpecBoostManager.SpecBoost<WitheringPlag
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(PoisonousHex.class).forEach(poisonousHex -> {
-                poisonousHex.setTickDuration(poisonousHex.getTickDuration() + (poisonousHex.getTicksBetweenDot() * poisonousHexDamagingTicksIncrease));
+                poisonousHex.setTickDuration(poisonousHex.getTickDuration() + poisonousHexTicksIncrease);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/WitheringPlague.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/WitheringPlague.java
@@ -1,6 +1,7 @@
 package com.ebicep.warlords.player.general.specboosts.boosts;
 
 import com.ebicep.warlords.abilities.AstralPlague;
+import com.ebicep.warlords.abilities.ContagiousFacade;
 import com.ebicep.warlords.abilities.PoisonousHex;
 import com.ebicep.warlords.abilities.internal.AbstractAbility;
 import com.ebicep.warlords.events.player.ingame.WarlordsAddCooldownEvent;
@@ -19,13 +20,13 @@ import java.util.List;
 
 public class WitheringPlague implements SpecBoostManager.SpecBoost<WitheringPlague> {
 
-    private float damageIncrease;
     private int poisonousHexTicksIncrease;
+    private float damageIncrease;
 
     @Override
     public void init() {
-        this.damageIncrease = getValue("damageIncrease", float.class);
         this.poisonousHexTicksIncrease = getValue("poisonousHexTicksIncrease", int.class);
+        this.damageIncrease = getValue("damageIncrease", float.class);
     }
 
     @Override
@@ -36,8 +37,8 @@ public class WitheringPlague implements SpecBoostManager.SpecBoost<WitheringPlag
     @Override
     public List<Object> getVariables() {
         return List.of(
-                damageIncrease,
-                poisonousHexTicksIncrease
+                poisonousHexTicksIncrease,
+                damageIncrease
         );
     }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/WitheringPlague.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/WitheringPlague.java
@@ -20,10 +20,12 @@ import java.util.List;
 public class WitheringPlague implements SpecBoostManager.SpecBoost<WitheringPlague> {
 
     private float damageIncrease;
+    private int poisonousHexDamagingTicksIncrease;
 
     @Override
     public void init() {
         this.damageIncrease = getValue("damageIncrease", float.class);
+        this.poisonousHexDamagingTicksIncrease = getValue("poisonousHexDamagingTicksIncrease", int.class);
     }
 
     @Override
@@ -33,7 +35,10 @@ public class WitheringPlague implements SpecBoostManager.SpecBoost<WitheringPlag
 
     @Override
     public List<Object> getVariables() {
-        return List.of(damageIncrease);
+        return List.of(
+                damageIncrease,
+                poisonousHexDamagingTicksIncrease
+        );
     }
 
     @Override
@@ -53,6 +58,9 @@ public class WitheringPlague implements SpecBoostManager.SpecBoost<WitheringPlag
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
+            warlordsPlayer.getAbilitiesMatching(PoisonousHex.class).forEach(poisonousHex -> {
+                poisonousHex.setTickDurationDot(poisonousHex.getTickDurationDot() + (poisonousHex.getTicksBetweenDot() * poisonousHexDamagingTicksIncrease));
+            });
         }
 
         @EventHandler(ignoreCancelled = true)


### PR DESCRIPTION
- Divine Effulgence: now reduces damage against primary (right click) abilities by 20%
- Eco Drive: increase single ally heal to 40% and light infusion cooldown to -3.5s
- Flame Breath: gets 2 charges
- Time Surge: increased heal to 35%
- Unstoppable Surge: increase infusion speed to 15% and knockback resistance to 30%
- Marked for Death: removed mark damage increase and radiance cooldown reduction
- Heroic Intervention: remove +1s on vene
- Holy Nova: limit enemies hit to 5
- Goliath: lowered max health increase to 800
- Seismic shift: increased wave wounding to 60%
- Mighty Fists: increase melee damage by 10% and additional 10% for every melee hit. resets when activating an ability
- Vitality Boost: increase passive healing to 60
- Chilly Aura: increase range to 8 blocks and damage to 3% max health
- Dirt Torpedo: reduce hit radius to 2 and increase damage to 40%
- Withering Plague: increase phex damaging ticks by 2
- Crusaders Might: increase damage to 30%
- Galvanized Spark: increased capacitor totem reduced damage to 20% and speed to 60%
- Eye of the Storm: increased range to 15 blocks
- Double Tap: increased speed duration to 4s
- Downpour: fixed healing rain charges at start of game