### PR TITLE
Pvp balance changes

### DIFF
--- a/config/ABILITIES.json
+++ b/config/ABILITIES.json
@@ -518,7 +518,7 @@
       },
       "flameBreath": {
         "name": "Flame Breath",
-        "cooldown": 9.5,
+        "cooldown": 8,
         "energyCost": 60,
         "maxAnimationTime": 12,
         "maxAnimationEffects": 4,
@@ -528,8 +528,8 @@
           "flameBreathDamage": {
             "min": 557,
             "max": 753,
-            "critChance": 20,
-            "critMultiplier": 175
+            "critChance": 25,
+            "critMultiplier": 185
           }
         }
       },

--- a/config/ABILITIES.json
+++ b/config/ABILITIES.json
@@ -518,18 +518,18 @@
       },
       "flameBreath": {
         "name": "Flame Breath",
-        "cooldown": 8,
-        "energyCost": 30,
+        "cooldown": 9.5,
+        "energyCost": 60,
         "maxAnimationTime": 12,
         "maxAnimationEffects": 4,
         "hitbox": 10,
         "velocity": 1,
         "damageValues": {
           "flameBreathDamage": {
-            "min": 390,
-            "max": 527,
-            "critChance": 25,
-            "critMultiplier": 185
+            "min": 557,
+            "max": 753,
+            "critChance": 20,
+            "critMultiplier": 175
           }
         }
       },
@@ -1532,7 +1532,9 @@
         "name": "Time Surge",
         "cooldown": 28,
         "energyCost": 30,
-        "healPercentage": 35
+        "healPercentage": 20,
+        "speedPercentage": 30,
+        "speedTickDuration": 50
       },
       "timeWarpAquamancer": {
         "name": "Time Warp",

--- a/config/SPEC_BOOSTS.json
+++ b/config/SPEC_BOOSTS.json
@@ -49,6 +49,21 @@
         "speedIncrease": 90,
         "damageIncrease": 10
       },
+      "infernoExplosion": {
+        "difficulty": 4,
+        "name": "Immolation Inferno",
+        "description": "Shorten the duration of {{aqua:Inferno}} by {{ticks}} and gain {{speed;%}} speed. Upon {{aqua:Inferno}} ending, lose {{damage;%}} of your health, deal {{damage}} + {{damage;%}} of that as damage within {{blue}} blocks, and gain {{damageReduction;%}} damage reduction for {{ticks}}.",
+        "infernoDurationReductionTicks": 220,
+        "infernoSpeedPercent": 25,
+        "healthLossPercent": 95,
+        "explosionDamageBase": 300,
+        "healthToDamagePercent": 20,
+        "explosionRadius": 5,
+        "damageReductionPercent": 99,
+        "damageReductionDurationTicks": 20,
+        "explosionCritChance": 20,
+        "explosionCritMultiplier": 110
+      },
       "portal": {
         "difficulty": 5,
         "disabled": true,

--- a/config/SPEC_BOOSTS.json
+++ b/config/SPEC_BOOSTS.json
@@ -15,9 +15,6 @@
         "difficulty": 3,
         "name": "Shotgun Pyro",
         "description": "Replace {{aqua:Flame Burst}} with {{aqua:Flame Breath}}, which has 2 charges. Replace {{aqua:Time Warp}} with {{aqua:Time Surge}}.",
-        "cooldownReductionPercent": 30,
-        "energyCostReductionPercent": 50,
-        "damageIncrease": -10,
         "maxAbilityCharges": 2
       },
       "burstChain": {
@@ -82,9 +79,10 @@
       "blizzardBreath": {
         "difficulty": 4,
         "name": "Blizzard Breath",
-        "description": "{{aqua:Freezing Breath}} reduces the cooldown of all your skills by {{ticks;%}} for each enemy hit and grants immunity to knockback and stun for {{ticks}}. Replace {{aqua:Time Warp}} with {{aqua:Time Surge}}. Reduce the cooldowns, energy costs, and healing/shield granted by {{aqua:Time Surge}} and {{aqua:Arcane Shield}} by {{blue;%}}",
+        "description": "{{aqua:Freezing Breath}} reduces all cooldowns by {{ticks;%}} per enemy hit and grants knockback and stun immunity for {{ticks}}. Each direct hit with {{aqua:Frostbolt}} reduces its cooldown by {{ticks}}. \n Replace {{aqua:Time Warp}} with {{aqua:Time Surge}}. {{aqua:Time Surge}} and {{aqua:Arcane Shield}} have reduced cooldowns, energy costs, and healing/shield by {{blue;%}}.",
         "cooldownReductionPerEnemyHitPercent": 2,
         "immunityDurationTicks": 40,
+        "frostboltDirectHitCooldownReductionTicks": 10,
         "productionValuesDecreasePercent": 30
       },
       "steadfastWarp": {
@@ -204,10 +202,9 @@
       "mightyFists": {
         "difficulty": 4,
         "name": "Mighty Fists",
-        "description": "Increase melee damage by {{damage;%}}. Every melee hit increases damage by another {{damage;%}}, up to {{damage;%}}. Activating any ability resets the bonus damage.",
-        "baseMeleePercent": 20,
-        "consecutiveHitIncreasePercent": 35,
-        "maxIncreasePercent": 90
+        "description": "Every melee hit gives damage stacks. Each stack increases damage by {{damage;%}}, up to {{damage;%}}. Activating any ability removes 1 stack.",
+        "consecutiveHitIncreasePercent": 20,
+        "maxIncreasePercent": 100
       },
       "seismicShift": {
         "difficulty": 2,
@@ -285,7 +282,7 @@
         "travelDistanceIncrease": 2,
         "damageReductionPercent": 15,
         "damageReductionDurationTicks": 40,
-        "verticalAscentDamage": 2000,
+        "verticalAscentDamage": 1500,
         "bonusVerticalBlocks": 1.5
       },
       "healingLink": {
@@ -303,9 +300,8 @@
       "oneManArmy": {
         "difficulty": 3,
         "name": "One Man Army",
-        "description": "Increase the duration of {{aqua:Undying Army}} by {{ticks}}, {{ticks}} for the caster. {{aqua:Undying Army}} will no longer heal nor damage you after being revived and resets the cooldown of {{aqua:Orbs of Life}}.",
-        "undyingArmyTickDurationIncrease": 40,
-        "undyingArmyTickDurationCaster": 360
+        "description": "Increase the duration of {{aqua:Undying Army}} by {{ticks}} for the caster. {{aqua:Undying Army}} will no longer damage you after being revived and resets the cooldown of {{aqua:Orbs of Life}} on revive.",
+        "undyingArmyTickDurationCaster": 200
       },
       "conduit": {
         "difficulty": 1,
@@ -484,7 +480,7 @@
         "difficulty": 4,
         "name": "Eye of the Storm",
         "description": "Reduce the range of {{aqua:Lightning Bolt}} to {{blocks}}, but increase the speed by {{speed;%}} and it will violently explode upon expiration or ground contact, with a {{blocks}} splash radius. Increase the {{aqua:Chain Lightning}} cooldown reduction from {{aqua:Lightning Bolt}} by {{ticks}}. {{aqua:Capacitor Totem}} can be casted to where you are looking (up to {{blocks}}), instantly procs on cast, and {{aqua:Lightning Rod}} always procs it.",
-        "maxTravelBlocks": 15,
+        "maxTravelBlocks": 20,
         "velocityIncreasePercentage": 100,
         "splashRadiusBlocks": 4,
         "chainCooldownReductionIncrease": 0.5,
@@ -592,8 +588,7 @@
       "riftAmbush": {
         "difficulty": 3,
         "name": "Rift Ambush",
-        "description": "Increase the range of {{aqua:Soul Switch}} by {{blocks}} and the damage reduction granted by {{damageReduction;%}}. {{aqua:Soul Switch}} will now only teleport you to your target, deal {{damage}} damage, and trap the target in a {{blocks}} radius for {{ticks}}.",
-        "soulSwitchRadiusIncrease": 5,
+        "description": "Increase the damage reduction of {{aqua:Soul Switch}} by {{damageReduction;%}}. {{aqua:Soul Switch}} will now only teleport you to your target, deal {{damage}} damage, and trap the target in a {{blocks}} radius for {{ticks}}.",
         "soulSwitchDamageReductionIncreasePercent": 15,
         "soulSwitchDamage": 400,
         "tetherRadius": 2,
@@ -616,12 +611,13 @@
       "abyssalGrasp": {
         "difficulty": 4,
         "name": "Abyssal Grasp",
-        "description": "Increase the damage of {{aqua:Soul Shackle}} by {{damage;%}} but increase the cooldown by {{ticks}} and reduce the range by {{blocks}}. {{aqua:Soul Shackle}} now pulls the target directly in front of you. Has reduced effect on flag carriers.",
+        "description": "Increase the damage of {{aqua:Soul Shackle}} by {{damage;%}} but increase the cooldown by {{ticks}} and reduce the range by {{blocks}}. {{aqua:Soul Shackle}} now pulls the target directly in front of you, while no longer silencing the target. Has reduced effect on flag carriers.",
         "soulShackleDamageIncreasePercent": 40,
         "soulShackleCooldownIncreaseTicks": 40,
         "soulShackleRangeDecrease": 4,
         "normalPullRange": 9,
-        "flagCarrierPullRange": 6
+        "flagCarrierPullRange": 6,
+        "silenceDurationTicks": 0
       },
       "vitalPulse": {
         "difficulty": 1,
@@ -738,8 +734,8 @@
         "difficulty": 2,
         "name": "Withering Plague",
         "description": "Increase the duration of {{dark_red:PHEX}} by {{ticks}}. For the duration of {{aqua:Astral Plague}}, increase the damage dealt to non-Tank enemies with max stacks of {{dark_red:PHEX}} by {{damage;%}}.",
-        "poisonousHexTicksIncrease": 80,
-        "damageIncrease": 30
+        "poisonousHexTicksIncrease": 40,
+        "damageIncrease": 20
       },
       "airStrike": {
         "difficulty": 5,
@@ -843,10 +839,11 @@
       "consecratedBeacon": {
         "difficulty": 2,
         "name": "Consecrated Beacon",
-        "description": "Reduce the energy cost of {{aqua:Sanctified Beacon}} by {{energy}}, the cooldown by {{ticks;%}}, and increase the {{dark_green:MHEX}} stacks granted by {{blue}}.",
+        "description": "Reduce the energy cost of {{aqua:Sanctified Beacon}} by {{energy}}, the cooldown by {{ticks;%}}, and increase the {{dark_green:MHEX}} stacks granted by {{blue}}. {{aqua:Sanctified Beacon}} now has {{blue}} charges",
         "sanctifiedBeaconEnergyCostDecrease": 10,
         "sanctifiedBeaconCooldownReductionPercent": 50,
-        "sanctifiedBeaconAdditionalHexStacks": 1
+        "sanctifiedBeaconAdditionalHexStacks": 1,
+        "maxAbilityCharges": 2
       },
       "holyNova": {
         "difficulty": 3,

--- a/config/SPEC_BOOSTS.json
+++ b/config/SPEC_BOOSTS.json
@@ -12,7 +12,7 @@
         "damageIncrease": 20
       },
       "flameBreath": {
-        "difficulty": 4,
+        "difficulty": 3,
         "name": "Shotgun Pyro",
         "description": "Replace {{aqua:Flame Burst}} with {{aqua:Flame Breath}}, which has 2 charges. Replace {{aqua:Time Warp}} with {{aqua:Time Surge}}.",
         "cooldownReductionPercent": 30,
@@ -21,7 +21,7 @@
         "maxAbilityCharges": 2
       },
       "burstChain": {
-        "difficulty": 2,
+        "difficulty": 4,
         "name": "Burst Chain",
         "description": "Lose {{heal}} max health but gain {{speed;%}} base speed. Increase the speed of {{aqua:Flame Burst}} by {{speed;%}} and it guarantees at least {{red}} critical hit. You deal {{damage;%}} more damage, {{damage;%}} with {{aqua:Inferno}} active, to enemies without the given damage reducing abilities active:\n\n{{aqua:Last Stand}}\n{{aqua:Ice Barrier}}\n{{aqua:Arcane Shield}}\n{{aqua:Prism Guard}}\n{{aqua:Intervene}}\n{{aqua:Solitary}}\n{{aqua:Ice Block}}\n{{aqua:Contagious Facade}}\n{{aqua:Mystical Barrier}}",
         "healthDecrease": 800,
@@ -43,7 +43,7 @@
         ]
       },
       "dimensionalWarp": {
-        "difficulty": 4,
+        "difficulty": 2,
         "name": "Dimensional Warp",
         "description": "Gain {{energy}} max energy. You will be warped back at {{heal;%}} health upon taking lethal damage. Reduce the duration of {{aqua:Time Warp}} by {{ticks}} but gain {{speed;%}} movement speed and {{damage;%}} damage for the duration. Warping back from lethal damage does not drop the flag.",
         "maxEnergyGain": 70,
@@ -80,7 +80,7 @@
         "directHitSlowIncrease": 5
       },
       "blizzardBreath": {
-        "difficulty": 3,
+        "difficulty": 4,
         "name": "Blizzard Breath",
         "description": "{{aqua:Freezing Breath}} reduces the cooldown of all your skills by {{ticks;%}} for each enemy hit and grants immunity to knockback and stun for {{ticks}}. Replace {{aqua:Time Warp}} with {{aqua:Time Surge}}. Reduce the cooldowns, energy costs, and healing/shield granted by {{aqua:Time Surge}} and {{aqua:Arcane Shield}} by {{blue;%}}",
         "cooldownReductionPerEnemyHitPercent": 2,
@@ -202,7 +202,7 @@
         "woundingStrikeEnergyCostReduction": 20
       },
       "mightyFists": {
-        "difficulty": 3,
+        "difficulty": 4,
         "name": "Mighty Fists",
         "description": "Increase melee damage by {{damage;%}}. Every melee hit increases damage by another {{damage;%}}, up to {{damage;%}}. Activating any ability resets the bonus damage.",
         "baseMeleePercent": 20,
@@ -218,7 +218,7 @@
         "seismicWaveWoundingTickDuration": 60
       },
       "bloodFrenzy": {
-        "difficulty": 4,
+        "difficulty": 5,
         "name": "Blood Frenzy",
         "description": "Reduce the cooldown of {{aqua:Bloodlust}} by {{ticks}}, the duration by {{ticks}}, and the energy cost by {{energy}}. Reduce its damage converted to healing by {{heal;%}} but it now heals an additional {{heal;%}} based on damage before any reductions. {{aqua:Berserk}} resets the cooldown of {{aqua:Bloodlust}}.",        "bloodLustCooldownReductionTicks": 400,
         "bloodLustDurationReductionTicks": 140,
@@ -227,7 +227,7 @@
         "bloodLustHealingPiercePercent": 25
       },
       "goliath": {
-        "difficulty": 2,
+        "difficulty": 1,
         "name": "Goliath",
         "description": "Gain {{heal}} max health and {{energy}} max energy. Increase the cooldown of {{aqua:Berserk}} by {{ticks}}; it heals you for {{heal}} true healing upon activation.",
         "healthIncrease": 800,
@@ -236,7 +236,7 @@
         "berserkActivationHeal": 1800
       },
       "vitalityBoost": {
-        "difficulty": 1,
+        "difficulty": 2,
         "name": "Vitality Boost",
         "description": "Gain {{heal}} max health. Passively heal for {{heal}} health per second.",
         "healthIncrease": 600,
@@ -257,7 +257,7 @@
         "groundSlamCooldownReductionPercent": 14
       },
       "heroicIntervention": {
-        "difficulty": 1,
+        "difficulty": 2,
         "name": "Heroic Intervention",
         "description": "Increase the max damage redirected by {{aqua:Intervene}} by {{damageReduction;}}, and the cast and break range by {{blocks}}.",
         "interveneCapIncrease": 1100,
@@ -278,7 +278,7 @@
         "horseHealth": 1500
       },
       "recklessAscent": {
-        "difficulty": 2,
+        "difficulty": 3,
         "name": "Reckless Ascent",
         "description": "Increase the radius of {{aqua:Reckless Charge}} by {{blocks}} and the range by {{blocks}}. Gain {{damageReduction;%}} damage reduction for {{ticks}} after casting {{aqua:Reckless Charge}}. {{aqua:Reckless Charge}} can ascend vertically, but you take {{damage}} when doing so.",
         "radiusIncrease": 1,
@@ -301,7 +301,7 @@
         "healingIncreasePercent": 20
       },
       "oneManArmy": {
-        "difficulty": 2,
+        "difficulty": 3,
         "name": "One Man Army",
         "description": "Increase the duration of {{aqua:Undying Army}} by {{ticks}}, {{ticks}} for the caster. {{aqua:Undying Army}} will no longer heal nor damage you after being revived and resets the cooldown of {{aqua:Orbs of Life}}.",
         "undyingArmyTickDurationIncrease": 40,
@@ -315,7 +315,7 @@
         "energyRemovalIncrease": 5
       },
       "armOfTheAlmighty": {
-        "difficulty": 1,
+        "difficulty": 3,
         "name": "Arm of the Almighty",
         "description": "{{aqua:Avenger's Strike}} will now cleave up to {{blue}} enemies within {{blocks}} for {{damage;%}} damage and will remove {{energy}} energy. During {{aqua:Avenger's Wrath}}, instead increase the damage of {{aqua:Avenger's Strike}} by {{damage;%}}.",
         "cleaveTargets": 2,
@@ -325,7 +325,7 @@
         "wrathDamageBoostPercent": 25
       },
       "unstoppableSurge": {
-        "difficulty": 3,
+        "difficulty": 2,
         "name": "Unstoppable Surge",
         "description": "{{aqua:Light Infusion}} heals you for {{heal}} health, increase the speed granted by {{speed;%}} and the duration by {{ticks}}. Heal an additional {{heal}} health if Avenger's Strike was not used for {{ticks}} after activating Light Infusion. Gain permanent {{speed;%}} slow resistance and {{damageReduction;%}} knockback resistance.",
         "lightInfusionHealing": 800,
@@ -347,7 +347,7 @@
         "avengerMarkDebuffTickDuration": 100
       },
       "wardingWrath": {
-        "difficulty": 1,
+        "difficulty": 3,
         "name": "Shaq Attack",
         "description": "Gain a {{damageReduction}} health shield each time you strike an enemy. Increase the radius of {{aqua:Avenger's Wrath}} by {{blocks}} and the shield health gained to {{damageReduction}} while active. Shields granted do not expire or have a limit.",
         "shieldPerStrike": 100,
@@ -361,7 +361,7 @@
         "damageIncreasePercent": 30
       },
       "parry": {
-        "difficulty": 4,
+        "difficulty": 3,
         "name": "Parry",
         "description": "Replace {{aqua:Consecrate}} with {{aqua:Parry}}, which has {{blue}} charges. Increase the energy granted by {{aqua:Crusader's Strike}} by {{energy}}.",
         "maxAbilityCharges": 2,
@@ -419,7 +419,7 @@
         "description": "Increase the healing of {{aqua:Holy Radiance}} by {{heal;%}} and the travel speed by {{speed;%}}. Allies healed by {{aqua:Holy Radiance}} gain {{damageReduction;%}} damage reduction against primary abilities for {{ticks}}.",
         "holyRadianceHealingIncreasePercent": 20,
         "holyRadianceTravelSpeedPercentIncrease": 200,
-        "primaryAbilityDamageReductionPercent": 20,
+        "primaryAbilityDamageReductionPercent": 40,
         "primaryAbilityDamageReductionDurationTicks": 100
       },
       "lustrousCrown": {
@@ -458,7 +458,7 @@
         "maxStacks": 3
       },
       "symphonicWindfury": {
-        "difficulty": 2,
+        "difficulty": 3,
         "name": "Double Tap",
         "description": "Increase the number of guaranteed hits of {{aqua:Windfury Weapon}} by {{blue}}. Upon cast, {{aqua:Windfury Weapon}} cleanses all slowness effects, grants {{speed;%}} slowness and knockback resistance and {{speed;%}} speed for {{ticks}}.",
         "windfuryExtraGuaranteedHits": 1,
@@ -572,7 +572,7 @@
         "healthTransferEffectivenessPercent": 70
       },
       "trickster": {
-        "difficulty": 4,
+        "difficulty": 3,
         "name": "Trickster",
         "description": "Reduce the bonus damage threshold of {{aqua:Incendiary Curse}} by {{damage;%}}, increase the damage by {{damage;%}} and the energy cost by {{energy}}. {{aqua:Soul Switch}} grants invisibility for {{ticks}} and leaves behind a dummy that lasts for {{ticks}}, has {{heal}} health, and damages enemies for how much they deal to it. Increase the healing threshold of {{aqua:Shadow Leap}} to {{heal}}.",
         "incendiaryCurseDamageThresholdDecrease": 10,
@@ -584,7 +584,7 @@
         "shadowLeapHealthThreshold": 5200
       },
       "blink": {
-        "difficulty": 2,
+        "difficulty": 5,
         "name": "Blink",
         "description": "Replace {{aqua:Soul Switch}} with Blink, which has {{blue}} charges.",
         "maxAbilityCharges": 2
@@ -727,7 +727,7 @@
         "energySeerEnergyIncrease": 10
       },
       "contagion": {
-        "difficulty": 2,
+        "difficulty": 3,
         "name": "Contagion",
         "description": "Gain {{energy}} energy per melee hit. Increase the damage reduction of {{aqua:Contagious Facade}} by {{damageReduction;%}} and the {{dark_red:PHEX}} stacks granted by {{blue}}, and its activation effect is activated on use and does not override the non-activation effect.",
         "ephIncrease": 2,
@@ -735,7 +735,7 @@
         "facadePhexStacksIncrease": 1
       },
       "witheringPlague": {
-        "difficulty": 3,
+        "difficulty": 2,
         "name": "Withering Plague",
         "description": "Increase the duration of {{dark_red:PHEX}} by {{ticks}}. For the duration of {{aqua:Astral Plague}}, increase the damage dealt to non-Tank enemies with max stacks of {{dark_red:PHEX}} by {{damage;%}}.",
         "poisonousHexTicksIncrease": 80,

--- a/src/main/java/com/ebicep/warlords/abilities/FlameBreath.java
+++ b/src/main/java/com/ebicep/warlords/abilities/FlameBreath.java
@@ -82,7 +82,7 @@ public class FlameBreath extends AbstractAbility implements RedAbilityIcon, Dama
                     .value(damageValues.flameBreathDamage)
             ).ifPresent(finalEvent -> {
                 Location loc = breathTarget.getLocation();
-                Vector v = wp.getLocation().toVector().subtract(loc.toVector()).normalize().multiply(-velocity).setY(0.2);
+                Vector v = wp.getLocation().toVector().subtract(loc.toVector()).normalize().multiply(-velocity).setY(0.15);
                 new GameRunnable(wp.getGame()) {
                     @Override
                     public void run() {

--- a/src/main/java/com/ebicep/warlords/abilities/TimeSurge.java
+++ b/src/main/java/com/ebicep/warlords/abilities/TimeSurge.java
@@ -17,6 +17,8 @@ public class TimeSurge extends AbstractAbility implements PurpleAbilityIcon, Abi
 
     private TimeSurgeStats stats = new TimeSurgeStats();
     protected float healPercentage = 30;
+    protected float speedPercentage = 30;
+    protected int speedTickDuration = 50;
 
     public TimeSurge() {
         super(AbstractAbilityBuilder.create("timeSurge").pvp());
@@ -26,6 +28,8 @@ public class TimeSurge extends AbstractAbility implements PurpleAbilityIcon, Abi
     public void init(AbstractAbilityBuilder builder) {
         super.init(builder);
         this.healPercentage = ConfigManager.getAbilityConfigValue(builder.getNamespaces(), builder.getAppendedFieldName("healPercentage"), float.class);
+        this.speedPercentage = ConfigManager.getAbilityConfigValue(builder.getNamespaces(), builder.getAppendedFieldName("speedPercentage"), float.class);
+        this.speedTickDuration = ConfigManager.getAbilityConfigValue(builder.getNamespaces(), builder.getAppendedFieldName("speedTickDuration"), int.class);
     }
 
     @Override
@@ -33,7 +37,11 @@ public class TimeSurge extends AbstractAbility implements PurpleAbilityIcon, Abi
         description = AbilityDescriptionBuilder
                 .create("Restore ")
                 .percent(healPercentage, NamedTextColor.GREEN)
-                .text(" of your health.")
+                .text(" of your health and gain ")
+                .percent(speedPercentage, NamedTextColor.YELLOW)
+                .text(" for ")
+                .durationTicks(speedTickDuration)
+                .text(".")
                 .build();
     }
 
@@ -41,6 +49,7 @@ public class TimeSurge extends AbstractAbility implements PurpleAbilityIcon, Abi
     @Override
     protected boolean onActivateInternal(@Nonnull WarlordsEntity wp) {
         Utils.playGlobalSound(wp.getLocation(), "mage.timewarp.activation", 3, 1);
+        wp.addSpeedModifier(wp, name, speedPercentage, speedTickDuration);
         wp.addInstance(InstanceBuilder
                 .healing()
                 .ability(this)
@@ -61,6 +70,22 @@ public class TimeSurge extends AbstractAbility implements PurpleAbilityIcon, Abi
 
     public void setHealPercentage(float healPercentage) {
         this.healPercentage = healPercentage;
+    }
+
+    public float getSpeedPercentage() {
+        return speedPercentage;
+    }
+
+    public void setSpeedPercentage(float speedPercentage) {
+        this.speedPercentage = speedPercentage;
+    }
+
+    public int getSpeedTickDuration() {
+        return speedTickDuration;
+    }
+
+    public void setSpeedTickDuration() {
+        this.speedTickDuration = speedTickDuration;
     }
 
     public static class TimeSurgeStats extends AbstractAbilityStats<TimeSurge, TimeSurge.TimeSurgeStats> {

--- a/src/main/java/com/ebicep/warlords/abilities/TimeSurge.java
+++ b/src/main/java/com/ebicep/warlords/abilities/TimeSurge.java
@@ -84,10 +84,6 @@ public class TimeSurge extends AbstractAbility implements PurpleAbilityIcon, Abi
         return speedTickDuration;
     }
 
-    public void setSpeedTickDuration() {
-        this.speedTickDuration = speedTickDuration;
-    }
-
     public static class TimeSurgeStats extends AbstractAbilityStats<TimeSurge, TimeSurge.TimeSurgeStats> {
 
         @Override

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/SpecBoostManager.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/SpecBoostManager.java
@@ -95,6 +95,7 @@ public class SpecBoostManager {
     public static final SpecBoost<StackulatorMax> STACKULATOR_MAX = new StackulatorMax();
     public static final SpecBoost<SteadfastWarp> STEADFAST_WARP = new SteadfastWarp();
     public static final SpecBoost<Striker> STRIKER = new Striker();
+    public static final SpecBoost<InfernoExplosion> INFERNO_EXPLOSION = new InfernoExplosion();
     public static final SpecBoost<SuperBrew> SUPER_BREW = new SuperBrew();
     public static final SpecBoost<SustainedOnslaught> SUSTAINED_ONSLAUGHT = new SustainedOnslaught();
     public static final SpecBoost<SwiftJustice> SWIFT_JUSTICE = new SwiftJustice();
@@ -120,7 +121,7 @@ public class SpecBoostManager {
     private static final Map<Specializations, List<SpecBoost<?>>> SPEC_BOOSTS = new HashMap<>();
 
     static {
-        SPEC_BOOSTS.put(Specializations.PYROMANCER, List.of(METEOR, FLAME_BREATH, BURST_CHAIN, DIMENSIONAL_WARP, PORTAL));
+        SPEC_BOOSTS.put(Specializations.PYROMANCER, List.of(METEOR, FLAME_BREATH, BURST_CHAIN, DIMENSIONAL_WARP, INFERNO_EXPLOSION));
         SPEC_BOOSTS.put(Specializations.CRYOMANCER, List.of(FROST_MISSILE, BLIZZARD_BREATH, STEADFAST_WARP, CHILLY_AURA, ICE_BLOCK));
         SPEC_BOOSTS.put(Specializations.AQUAMANCER, List.of(TYPHOON_BOLT, SYRINGE, DIVINE_PURIFICATION, CLAIRVOYANCE, DOWNPOUR));
         SPEC_BOOSTS.put(Specializations.BERSERKER, List.of(EFFICIENT_STRIKES, MIGHTY_FISTS, SEISMIC_SHIFT, BLOOD_FRENZY, GOLIATH));

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AbyssalGrasp.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/AbyssalGrasp.java
@@ -22,6 +22,7 @@ public class AbyssalGrasp implements SpecBoostManager.SpecBoost<AbyssalGrasp> {
     private int soulShackleRangeDecrease;
     private float normalPullRange;
     private float flagCarrierPullRange;
+    private int silenceDurationTicks;
 
     @Override
     public void init() {
@@ -30,6 +31,7 @@ public class AbyssalGrasp implements SpecBoostManager.SpecBoost<AbyssalGrasp> {
         this.soulShackleRangeDecrease = getValue("soulShackleRangeDecrease", int.class);
         this.normalPullRange = getValue("normalPullRange", float.class);
         this.flagCarrierPullRange = getValue("flagCarrierPullRange", float.class);
+        this.silenceDurationTicks = getValue("silenceDurationTicks", int.class);
     }
 
     @Override
@@ -39,7 +41,7 @@ public class AbyssalGrasp implements SpecBoostManager.SpecBoost<AbyssalGrasp> {
 
     @Override
     public List<Object> getVariables() {
-        return List.of(soulShackleDamageIncreasePercent, soulShackleCooldownIncreaseTicks, soulShackleRangeDecrease, normalPullRange, flagCarrierPullRange);
+        return List.of(soulShackleDamageIncreasePercent, soulShackleCooldownIncreaseTicks, soulShackleRangeDecrease, normalPullRange, flagCarrierPullRange, silenceDurationTicks);
     }
 
     @Override
@@ -69,6 +71,7 @@ public class AbyssalGrasp implements SpecBoostManager.SpecBoost<AbyssalGrasp> {
                 soulShackle.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", soulShackleCooldownIncreaseTicks / 20f);
                 this.soulShackleRange = soulShackle.getShackleRange() - soulShackleRangeDecrease;
                 soulShackle.setShackleRange(soulShackleRange);
+                soulShackle.setSilenceDurationInTicks(silenceDurationTicks);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Blink.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Blink.java
@@ -52,8 +52,8 @@ public class Blink implements SpecBoostManager.SpecBoost<Blink> {
                 if (ability instanceof SoulSwitch) {
                     com.ebicep.warlords.abilities.Blink blink = new com.ebicep.warlords.abilities.Blink();
                     blink.setMaxCharges(maxAbilityCharges);
+                    blink.setCurrentCharges(maxAbilityCharges);
                     blink.init(blink.getBuilder());
-                    blink.setCurrentCooldown(1);
                     abilities.set(i, blink);
                 }
             }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BlizzardBreath.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BlizzardBreath.java
@@ -14,6 +14,7 @@ import com.ebicep.warlords.player.ingame.WarlordsEntity;
 import com.ebicep.warlords.player.ingame.WarlordsPlayer;
 import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
 import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
+import com.ebicep.warlords.player.ingame.instances.InstanceFlags;
 import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
 import net.kyori.adventure.text.TextComponent;
 import org.bukkit.event.EventHandler;
@@ -28,12 +29,14 @@ public class BlizzardBreath implements SpecBoostManager.SpecBoost<BlizzardBreath
 
     private float cooldownReductionPerEnemyHitPercent;
     private int immunityDurationTicks;
+    private int frostboltDirectHitCooldownReductionTicks;
     private int productionValuesDecreasePercent;
 
     @Override
     public void init() {
         this.cooldownReductionPerEnemyHitPercent = getValue("cooldownReductionPerEnemyHitPercent", float.class);
         this.immunityDurationTicks = getValue("immunityDurationTicks", int.class);
+        this.frostboltDirectHitCooldownReductionTicks = getValue("frostboltDirectHitCooldownReductionTicks", int.class);
         this.productionValuesDecreasePercent = getValue("productionValuesDecreasePercent", int.class);
     }
 
@@ -49,7 +52,7 @@ public class BlizzardBreath implements SpecBoostManager.SpecBoost<BlizzardBreath
 
     @Override
     public List<Object> getVariables() {
-        return List.of(cooldownReductionPerEnemyHitPercent, immunityDurationTicks, productionValuesDecreasePercent);
+        return List.of(cooldownReductionPerEnemyHitPercent, immunityDurationTicks, frostboltDirectHitCooldownReductionTicks, productionValuesDecreasePercent);
     }
 
     @Override
@@ -107,6 +110,23 @@ public class BlizzardBreath implements SpecBoostManager.SpecBoost<BlizzardBreath
             } else {
                 breathTargetsHit.put(uuid, 1);
             }
+        }
+
+        @EventHandler
+        public void onFrostboltDirectHit(WarlordsDamageHealingFinalEvent event) {
+            WarlordsDamageHealingEvent damageHealingEvent = event.getWarlordsDamageHealingEvent();
+            if (!damageHealingEvent.getSource().equals(warlordsEntity)) {
+                return;
+            }
+            if (!damageHealingEvent.getCause().equals("Frostbolt")) {
+                return;
+            }
+            if (!damageHealingEvent.getFlags().contains(InstanceFlags.DIRECT_HIT)) {
+                return;
+            }
+            warlordsEntity.getAbilitiesMatching(FreezingBreath.class).forEach(freezingBreath -> {
+                freezingBreath.subtractCurrentCooldown(frostboltDirectHitCooldownReductionTicks);
+            });
         }
 
         @EventHandler

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BlizzardBreath.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/BlizzardBreath.java
@@ -1,6 +1,7 @@
 package com.ebicep.warlords.player.general.specboosts.boosts;
 
 import com.ebicep.warlords.abilities.FreezingBreath;
+import com.ebicep.warlords.abilities.FrostBolt;
 import com.ebicep.warlords.abilities.TimeSurge;
 import com.ebicep.warlords.abilities.TimeWarpCryomancer;
 import com.ebicep.warlords.abilities.internal.AbstractAbility;
@@ -118,14 +119,17 @@ public class BlizzardBreath implements SpecBoostManager.SpecBoost<BlizzardBreath
             if (!damageHealingEvent.getSource().equals(warlordsEntity)) {
                 return;
             }
-            if (!damageHealingEvent.getCause().equals("Frostbolt")) {
+            if (!damageHealingEvent.isDamageInstance()) {
+                return;
+            }
+            if (!(damageHealingEvent.getAbility() instanceof FrostBolt)) {
                 return;
             }
             if (!damageHealingEvent.getFlags().contains(InstanceFlags.DIRECT_HIT)) {
                 return;
             }
             warlordsEntity.getAbilitiesMatching(FreezingBreath.class).forEach(freezingBreath -> {
-                freezingBreath.subtractCurrentCooldown(frostboltDirectHitCooldownReductionTicks);
+                freezingBreath.subtractCurrentCooldown(frostboltDirectHitCooldownReductionTicks / 20f);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ConsecratedBeacon.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ConsecratedBeacon.java
@@ -12,12 +12,14 @@ public class ConsecratedBeacon implements SpecBoostManager.SpecBoost<Consecrated
     private float sanctifiedBeaconEnergyCostDecrease;
     private float sanctifiedBeaconCooldownReductionPercent;
     private int sanctifiedBeaconAdditionalHexStacks;
+    private int maxAbilityCharges;
 
     @Override
     public void init() {
         this.sanctifiedBeaconEnergyCostDecrease = getValue("sanctifiedBeaconEnergyCostDecrease", float.class);
         this.sanctifiedBeaconCooldownReductionPercent = getValue("sanctifiedBeaconCooldownReductionPercent", float.class);
         this.sanctifiedBeaconAdditionalHexStacks = getValue("sanctifiedBeaconAdditionalHexStacks", int.class);
+        this.maxAbilityCharges = getValue("maxAbilityCharges", int.class);
     }
 
     @Override
@@ -27,7 +29,7 @@ public class ConsecratedBeacon implements SpecBoostManager.SpecBoost<Consecrated
 
     @Override
     public List<Object> getVariables() {
-        return List.of(sanctifiedBeaconEnergyCostDecrease, sanctifiedBeaconCooldownReductionPercent, sanctifiedBeaconAdditionalHexStacks);
+        return List.of(sanctifiedBeaconEnergyCostDecrease, sanctifiedBeaconCooldownReductionPercent, sanctifiedBeaconAdditionalHexStacks, maxAbilityCharges);
     }
 
     @Override
@@ -48,6 +50,8 @@ public class ConsecratedBeacon implements SpecBoostManager.SpecBoost<Consecrated
                 sanctifiedBeacon.getEnergyCost().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -sanctifiedBeaconEnergyCostDecrease);
                 sanctifiedBeacon.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE_MULTIPLIER, "Spec Boost", -sanctifiedBeaconCooldownReductionPercent / 100);
                 sanctifiedBeacon.setStacksGranted(sanctifiedBeacon.getStacksGranted() + sanctifiedBeaconAdditionalHexStacks);
+                sanctifiedBeacon.setMaxCharges(maxAbilityCharges);
+                sanctifiedBeacon.setCurrentCooldown(0);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ConsecratedBeacon.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/ConsecratedBeacon.java
@@ -51,7 +51,7 @@ public class ConsecratedBeacon implements SpecBoostManager.SpecBoost<Consecrated
                 sanctifiedBeacon.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE_MULTIPLIER, "Spec Boost", -sanctifiedBeaconCooldownReductionPercent / 100);
                 sanctifiedBeacon.setStacksGranted(sanctifiedBeacon.getStacksGranted() + sanctifiedBeaconAdditionalHexStacks);
                 sanctifiedBeacon.setMaxCharges(maxAbilityCharges);
-                sanctifiedBeacon.setCurrentCooldown(0);
+                sanctifiedBeacon.setCurrentCharges(maxAbilityCharges);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Downpour.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/Downpour.java
@@ -70,14 +70,13 @@ public class Downpour implements SpecBoostManager.SpecBoost<Downpour> {
             });
             warlordsPlayer.getAbilitiesMatching(HealingRain.class).forEach(healingRain -> {
                 healingRain.setMaxCharges(healingRainMaxCharges);
+                healingRain.setCurrentCharges(healingRainMaxCharges);
                 healingRain.getCooldown().addModifier(FloatModifiable.ModifierType.ADDITIVE_MULTIPLIER, "Spec Boost", -healingRainCooldownReductionPercent / 100);
                 healingRain.getHealValues().getRainHealing().forEachValue(floatModifiable ->
                         floatModifiable.addModifier(FloatModifiable.ModifierType.ADDITIVE_MULTIPLIER, "Spec Boost", healingRainHealingIncreasePercent / 100)
                 );
                 healingRain.setTickDuration(Math.round(healingRain.getTickDuration() * (1 - healingRainDurationDecreasePercent / 100)));
                 healingRain.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", -healingRainRadiusDecreaseBlocks);
-                healingRain.setCurrentCooldown(0);
-                healingRain.setCurrentCooldown(0);
             });
         }
 

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/FlameBreath.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/FlameBreath.java
@@ -59,8 +59,8 @@ public class FlameBreath implements SpecBoostManager.SpecBoost<FlameBreath> {
                 if (abilities.get(i) instanceof FlameBurst) {
                     com.ebicep.warlords.abilities.FlameBreath flameBreath = new com.ebicep.warlords.abilities.FlameBreath();
                     flameBreath.setMaxCharges(maxAbilityCharges);
+                    flameBreath.setMaxCharges(maxAbilityCharges);
                     flameBreath.init(flameBreath.getBuilder());
-                    flameBreath.setCurrentCooldown(1);
                     abilities.set(i, flameBreath);
                 } else if (abilities.get(i) instanceof TimeWarpPyromancer) {
                     TimeSurge timeSurge = new TimeSurge();

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/InfernoExplosion.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/InfernoExplosion.java
@@ -1,0 +1,137 @@
+package com.ebicep.warlords.player.general.specboosts.boosts;
+
+import com.ebicep.warlords.abilities.Inferno;
+import com.ebicep.warlords.events.player.ingame.WarlordsAddCooldownEvent;
+import com.ebicep.warlords.player.general.specboosts.SpecBoostManager;
+import com.ebicep.warlords.player.ingame.WarlordsEntity;
+import com.ebicep.warlords.player.ingame.WarlordsPlayer;
+import com.ebicep.warlords.player.ingame.cooldowns.AbstractCooldown;
+import com.ebicep.warlords.player.ingame.cooldowns.cooldowns.RegularCooldown;
+import com.ebicep.warlords.player.ingame.instances.InstanceBuilder;
+import com.ebicep.warlords.util.warlords.PlayerFilter;
+import com.ebicep.warlords.player.ingame.cooldowns.CooldownTypes;
+import com.ebicep.warlords.player.ingame.instances.type.Modifier;
+import com.ebicep.warlords.util.warlords.modifiablevalues.FloatModifiable;
+import java.util.Collections;
+import org.bukkit.event.EventHandler;
+
+import java.util.List;
+
+public class InfernoExplosion implements SpecBoostManager.SpecBoost<InfernoExplosion>{
+
+    private int infernoDurationReductionTicks;
+    private float infernoSpeedPercent;
+    private float healthLossPercent;
+    private float explosionDamageBase;
+    private float healthToDamagePercent;
+    private int explosionRadius;
+    private float damageReductionPercent;
+    private int damageReductionDurationTicks;
+    private int explosionCritChance; // +30 from inferno bonus
+    private int explosionCritMultiplier; // +30 from inferno bonus
+
+    @Override
+    public void init() {
+        this.infernoDurationReductionTicks = getValue("infernoDurationReductionTicks", int.class);
+        this.infernoSpeedPercent = getValue("infernoSpeedPercent", float.class);
+        this.healthLossPercent = getValue("healthLossPercent", float.class);
+        this.explosionDamageBase = getValue("explosionDamageBase", float.class);
+        this.healthToDamagePercent = getValue("healthToDamagePercent", float.class);
+        this.explosionRadius = getValue("explosionRadius", int.class);
+        this.damageReductionPercent = getValue("damageReductionPercent", float.class);
+        this.damageReductionDurationTicks = getValue("damageReductionDurationTicks", int.class);
+        this.explosionCritChance = getValue("explosionCritChance", int.class);
+        this.explosionCritMultiplier = getValue("explosionCritMultiplier", int.class);
+    }
+
+    @Override
+    public String getConfigFieldName() {
+        return "infernoExplosion";
+    }
+
+    @Override
+    public List<Object> getVariables() {
+        return List.of(infernoDurationReductionTicks, infernoSpeedPercent, healthLossPercent, explosionDamageBase, healthToDamagePercent, explosionRadius, damageReductionPercent, damageReductionDurationTicks, explosionCritChance);
+    }
+
+    @Override
+    public SpecBoostManager.Boost create() {
+        return new Boost();
+    }
+
+    @Override
+    public InfernoExplosion get() {
+        return this;
+    }
+
+    public class Boost implements SpecBoostManager.Boost {
+
+        private WarlordsEntity warlordsEntity;
+
+        private Inferno infernoAbility;
+
+        @Override
+        public void apply(WarlordsPlayer warlordsplayer) {
+            this.warlordsEntity = warlordsplayer;
+            warlordsplayer.getAbilitiesMatching(Inferno.class).forEach(inferno -> {
+                this.infernoAbility = inferno;
+                inferno.setTickDuration(inferno.getTickDuration() - infernoDurationReductionTicks);
+            });
+        }
+
+        @EventHandler(ignoreCancelled = true)
+        public void onCooldownAddEvent(WarlordsAddCooldownEvent event) {
+            if (!warlordsEntity.equals(event.getWarlordsEntity())) {
+                return;
+            }
+            AbstractCooldown<?> cooldown = event.getAbstractCooldown();
+            if (!(cooldown instanceof RegularCooldown<?> regularCooldown)) {
+                return;
+            }
+            if (!cooldown.getCooldownClass().equals(Inferno.class) || !cooldown.getFrom().equals(warlordsEntity)) {
+                return;
+            }
+            warlordsEntity.addSpeedModifier(warlordsEntity, cooldown.getName(), infernoSpeedPercent, regularCooldown.getTicksLeft());
+            regularCooldown.addTriConsumer((cd, ticksLeft, ticksElapsed) -> {
+                if (ticksLeft <= 1) {
+                    triggerExplosion();
+                }
+            });
+        }
+
+        private void triggerExplosion() {
+            if (warlordsEntity == null) return;
+
+            float healthLost = warlordsEntity.getCurrentHealth() * healthLossPercent / 100;
+            float explosionDamage = explosionDamageBase + healthLost * healthToDamagePercent / 100;
+
+            warlordsEntity.addInstance(InstanceBuilder
+                    .fall()
+                    .source(warlordsEntity)
+                    .value(healthLost)
+            );
+            for (WarlordsEntity target : PlayerFilter
+                    .entitiesAround(warlordsEntity, explosionRadius, explosionRadius, explosionRadius)
+                    .aliveEnemiesOf(warlordsEntity)
+            ) {
+                target.addInstance(InstanceBuilder
+                        .damage()
+                        .ability(infernoAbility)
+                        .source(warlordsEntity)
+                        .value(explosionDamage)
+                        .critChance(explosionCritChance)
+                        .critMultiplier(explosionCritMultiplier)
+                );
+            }
+            warlordsEntity.getCooldownManager().addCooldown(new RegularCooldown<>(
+                    "Inferno Shield", null, InfernoExplosion.class, null, warlordsEntity,
+                    CooldownTypes.BUFF,
+                    cooldownManager -> {},
+                    damageReductionDurationTicks,
+                    Collections.emptyList()
+            ).addModifier(Modifier.MODIFY_INCOMING_DAMAGE_AFTER_INTERVENE , (event, currentDamageValue) -> {
+                currentDamageValue.addModifier(FloatModifiable.ModifierType.MULTIPLICATIVE_MULTIPLIER, "Inferno Shield", 1 - damageReductionPercent / 100);
+            }));
+        }
+    }
+}

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/InfernoExplosion.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/InfernoExplosion.java
@@ -88,15 +88,11 @@ public class InfernoExplosion implements SpecBoostManager.SpecBoost<InfernoExplo
             if (!(cooldown instanceof RegularCooldown<?> regularCooldown)) {
                 return;
             }
-            if (!cooldown.getCooldownClass().equals(Inferno.class) || !cooldown.getFrom().equals(warlordsEntity)) {
+            if (!cooldown.getCooldownClass().equals(Inferno.class)) {
                 return;
             }
             warlordsEntity.addSpeedModifier(warlordsEntity, cooldown.getName(), infernoSpeedPercent, regularCooldown.getTicksLeft());
-            regularCooldown.addTriConsumer((cd, ticksLeft, ticksElapsed) -> {
-                if (ticksLeft <= 1) {
-                    triggerExplosion();
-                }
-            });
+            regularCooldown.setOnRemove((cooldownManager) -> triggerExplosion());
         }
 
         private void triggerExplosion() {

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MightyFists.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/MightyFists.java
@@ -15,14 +15,12 @@ import java.util.List;
 
 public class MightyFists implements SpecBoostManager.SpecBoost<MightyFists> {
 
-    private float meleeIncreasePercent;
-    private float baseMeleePercent;
+    private float baseMeleePercent = 0;
     private float consecutiveHitIncreasePercent;
     private float maxIncreasePercent;
 
     @Override
     public void init() {
-        this.baseMeleePercent = getValue("baseMeleePercent", float.class);
         this.consecutiveHitIncreasePercent = getValue("consecutiveHitIncreasePercent", float.class);
         this.maxIncreasePercent = getValue("maxIncreasePercent", float.class);
     }
@@ -34,8 +32,7 @@ public class MightyFists implements SpecBoostManager.SpecBoost<MightyFists> {
 
     @Override
     public List<Object> getVariables() {
-        return List.of(baseMeleePercent,
-                consecutiveHitIncreasePercent,
+        return List.of(consecutiveHitIncreasePercent,
                 maxIncreasePercent
         );
     }
@@ -81,7 +78,7 @@ public class MightyFists implements SpecBoostManager.SpecBoost<MightyFists> {
             if (!warlordsEntity.equals(event.getWarlordsEntity())) {
                 return;
             }
-            meleeDamageBoost = baseMeleePercent;
+            meleeDamageBoost = Math.max(meleeDamageBoost - consecutiveHitIncreasePercent, baseMeleePercent);;
         }
 
         @EventHandler

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/OneManArmy.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/OneManArmy.java
@@ -15,12 +15,10 @@ import java.util.function.BiConsumer;
 
 public class OneManArmy implements SpecBoostManager.SpecBoost<OneManArmy> {
 
-    private int undyingArmyTickDurationIncrease;
     private int undyingArmyTickDurationCaster;
 
     @Override
     public void init() {
-        this.undyingArmyTickDurationIncrease = getValue("undyingArmyTickDurationIncrease", int.class);
         this.undyingArmyTickDurationCaster = getValue("undyingArmyTickDurationCaster", int.class);
     }
 
@@ -31,7 +29,7 @@ public class OneManArmy implements SpecBoostManager.SpecBoost<OneManArmy> {
 
     @Override
     public List<Object> getVariables() {
-        return List.of(undyingArmyTickDurationIncrease, undyingArmyTickDurationCaster);
+        return List.of(undyingArmyTickDurationCaster);
     }
 
     @Override
@@ -51,9 +49,6 @@ public class OneManArmy implements SpecBoostManager.SpecBoost<OneManArmy> {
         @Override
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
-            warlordsPlayer.getAbilitiesMatching(UndyingArmy.class).forEach(undyingArmy -> {
-                undyingArmy.setTickDuration(undyingArmy.getTickDuration() + undyingArmyTickDurationIncrease);
-            });
         }
 
         @EventHandler(ignoreCancelled = true)
@@ -75,12 +70,13 @@ public class OneManArmy implements SpecBoostManager.SpecBoost<OneManArmy> {
                     oldOnPop.accept(cd, we);
                 } else {
                     cd.setTicksLeft(1);
+                    for (OrbsOfLife orbsOfLife : warlordsEntity.getAbilitiesMatching(OrbsOfLife.class)) {
+                        orbsOfLife.setCurrentCooldown(0);
+                    }
                 }
             });
             regularCooldown.getConsumers().clear();
-            for (OrbsOfLife orbsOfLife : warlordsEntity.getAbilitiesMatching(OrbsOfLife.class)) {
-                orbsOfLife.setCurrentCooldown(0);
-            }
+
         }
 
     }

--- a/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/RiftAmbush.java
+++ b/src/main/java/com/ebicep/warlords/player/general/specboosts/boosts/RiftAmbush.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 public class RiftAmbush implements SpecBoostManager.SpecBoost<RiftAmbush> {
 
-    private float soulSwitchRadiusIncrease;
     private int soulSwitchDamageReductionIncreasePercent;
     private float soulSwitchDamage;
     private float tetherRadius;
@@ -30,7 +29,6 @@ public class RiftAmbush implements SpecBoostManager.SpecBoost<RiftAmbush> {
 
     @Override
     public void init() {
-        this.soulSwitchRadiusIncrease = getValue("soulSwitchRadiusIncrease", float.class);
         this.soulSwitchDamageReductionIncreasePercent = getValue("soulSwitchDamageReductionIncreasePercent", int.class);
         this.soulSwitchDamage = getValue("soulSwitchDamage", float.class);
         this.tetherRadius = getValue("tetherRadius", float.class);
@@ -45,7 +43,7 @@ public class RiftAmbush implements SpecBoostManager.SpecBoost<RiftAmbush> {
 
     @Override
     public List<Object> getVariables() {
-        return List.of(soulSwitchRadiusIncrease, soulSwitchDamageReductionIncreasePercent, soulSwitchDamage, tetherRadius, tetherTickDuration);
+        return List.of(soulSwitchDamageReductionIncreasePercent, soulSwitchDamage, tetherRadius, tetherTickDuration);
     }
 
     @Override
@@ -66,7 +64,6 @@ public class RiftAmbush implements SpecBoostManager.SpecBoost<RiftAmbush> {
         public void apply(WarlordsPlayer warlordsPlayer) {
             this.warlordsEntity = warlordsPlayer;
             warlordsPlayer.getAbilitiesMatching(SoulSwitch.class).forEach(soulSwitch -> {
-                soulSwitch.getHitBoxRadius().addModifier(FloatModifiable.ModifierType.ADDITIVE, "Spec Boost", soulSwitchRadiusIncrease);
                 soulSwitch.setVerticalLimit(soulSwitchVerticalLimit);
                 soulSwitch.setDamageReduction(soulSwitch.getDamageReduction() + soulSwitchDamageReductionIncreasePercent);
                 soulSwitch.setCanSwitchToCarrier(true);


### PR DESCRIPTION
**Echoes of Demise - v1.29.0**

**Patch Notes**

---

**Spec Boosts**

**One Man Army**
•    Removed duration increase on allies
•    18 second increase on caster ---> 10 seconds
•    Orbs of Life cooldown resets when you pop instead of on cast.

**Reckless Ascent**
•    Damage taken while ascending: 2000 --> 1500

**Mighty Fists**
•    Now increases melee damage by 20% for each melee hit (these are stacks)
•    Maximum melee damage: 90% --> 100%
•    Using an ability loses one stack of melee damage (20% melee damage unless you have no stacks)

**Consecrated Beacon**
•    Sanctified Beacon has 2 charges

**Divine Effulgence**
•    Damage reduction from Holy Radiance: 20% --> 40%

**Eye of the Storm**
•    Block Range Limit: 15 blocks --> 20 blocks

**Withering Plague**
•    PHEX increase: 4s --> 2s
•    Astral Plague damage on Non-Tanks: 30% --> 20%

**Abyssal Grasp**
•    Removed silence effect when casting Soul Shackle.

**Rift Ambush**
•    Removed the increased range from Soul Switch. 

**Shotgun Pyro**
•    Now has the same damage, cooldown and energy cost as Flame Burst
•    Reduced crit chance and crit multiplier.
•    Slightly reduced knockback

**Blizzard Breath**
•    Direct hits with frostbolt reduce freezing breath cooldown by 0.5s

**Time Surge**
•    Heal 35% --> 20%
•    Added 30% speed for 2.5s 

**New Pyromancer Boost: Immolation Inferno**
Shorten the duration of Inferno by 11 seconds and gain 25% speed. Upon Inferno ending, lose 95% of your health, deal 300 + 20% of that as damage within 5 blocks, and gain 99% damage reduction for 1 second. 

Changed some skill boost difficulties